### PR TITLE
chore: sync with upstream prism-mcp (v9.4.7 → v9.12.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,39 @@
-# 🧠 Prism MCP — The Mind Palace for AI Agents
+# 🧠 Prism MCP — The Mind Palace for AI Agents (Local Embeddings Fork)
+
+> **This is a fork of [dcostenco/prism-mcp](https://github.com/dcostenco/prism-mcp).** The changes below are the only differences from upstream.
+
+## What This Fork Changes
+
+Upstream Prism requires a `GOOGLE_API_KEY` (or other cloud API key) for semantic vector search — the feature that powers `session_search_memory`, embedding generation on save, SDM Intuitive Recall, and fact consolidation. **This fork removes that requirement** by adding a fully local embedding provider, so all semantic features work offline with zero API keys.
+
+### Added: Local Embedding Provider
+
+A new `LocalEmbeddingAdapter` runs the [nomic-ai/nomic-embed-text-v1.5](https://huggingface.co/nomic-ai/nomic-embed-text-v1.5) model on your machine via [`@huggingface/transformers`](https://github.com/huggingface/transformers.js). No network calls, no API keys, no cost.
+
+To enable it, set these in the Prism dashboard or environment:
+
+```
+embedding_provider=local
+text_provider=none        # optional — disables text generation if you don't have a key
+```
+
+The model downloads once (~100 MB quantized) and runs locally on subsequent starts.
+
+### Added: Disabled Text Adapter
+
+A `DisabledTextAdapter` (`text_provider=none`) lets you run Prism without any text generation API key. Features that require text generation (like fact consolidation via Gemini) will throw a clear error pointing you to configure a provider, rather than failing silently.
+
+### Removed: Hardcoded `GOOGLE_API_KEY` Guards
+
+Upstream had six `GOOGLE_API_KEY` checks scattered across handler files that would silently skip embedding generation, semantic search, SDM recall, and fact consolidation when no key was set — even if a local provider was configured. This fork removes all of them. The factory pattern now handles provider resolution: if a provider is configured, it works; if not, it throws a clear error on first call.
+
+**Files changed:** `graphHandlers.ts`, `ledgerHandlers.ts`, `factMerger.ts`, `dashboard/server.ts`, `factory.ts`
+
+### Upstream Status
+
+This fork diverged from upstream at `ecd1424` (v9.4.6). The changes are conceptually independent from upstream's recent work (security hardening, ABA protocol, split-brain fixes), but merging will require conflict resolution since both sides modified some of the same files.
+
+---
 
 [![npm version](https://img.shields.io/npm/v/prism-mcp-server?color=cb0000&label=npm)](https://www.npmjs.com/package/prism-mcp-server)
 [![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed-00ADD8?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0id2hpdGUiIGQ9Ik0xMiAyTDIgN2wxMCA1IDEwLTUtMTAtNXpNMiAxN2wxMCA1IDEwLTV2LTJMMTI0djJMMiA5djh6Ii8+PC9zdmc+)](https://github.com/modelcontextprotocol/servers)

--- a/README.md
+++ b/README.md
@@ -124,16 +124,16 @@ Then open `http://localhost:3001` instead.
 | Time travel & versioning | ✅ | ✅ |
 | Mind Palace Dashboard | ✅ | ✅ |
 | GDPR export (JSON/Markdown/Vault) | ✅ | ✅ |
-| Semantic vector search | ❌ | ✅ `GOOGLE_API_KEY` |
-| Morning Briefings | ❌ | ✅ `GOOGLE_API_KEY` |
-| Auto-compaction | ❌ | ✅ `GOOGLE_API_KEY` |
+| Semantic vector search | ✅ (`embedding_provider=local`) | ✅ (gemini, openai, or voyage) |
+| Morning Briefings | ❌ | ✅ Text provider key |
+| Auto-compaction | ❌ | ✅ Text provider key |
 | Web Scholar research | ❌ | ✅ [`BRAVE_API_KEY`](#environment-variables) + [`FIRECRAWL_API_KEY`](#environment-variables) (or `TAVILY_API_KEY`) |
 | VLM image captioning | ❌ | ✅ Provider key |
-| Autonomous Pipelines (Dark Factory) | ❌ | ✅ `GOOGLE_API_KEY` (or LLM override) |
+| Autonomous Pipelines (Dark Factory) | ❌ | ✅ Text provider key |
 
-> 🔑 The core Mind Palace works **100% offline** with zero API keys. Cloud keys unlock intelligence features. See [Environment Variables](#environment-variables).
+> 🔑 The core Mind Palace works **100% offline** with zero API keys — including semantic vector search with `embedding_provider=local`. Cloud keys unlock text generation features (Briefings, compaction, pipelines). See [Environment Variables](#environment-variables).
 
-> 💰 **API Cost Note:** `GOOGLE_API_KEY` (Gemini) has a generous free tier that covers most individual use. `BRAVE_API_KEY` offers 2,000 free searches/month. `FIRECRAWL_API_KEY` has a free plan with 500 credits. For typical solo development, expect **$0/month** on the free tiers. Only high-volume teams or heavy autonomous pipeline usage will incur meaningful costs.
+> 💰 **API Cost Note:** With `embedding_provider=local`, semantic search is fully free and offline. Cloud providers (`GOOGLE_API_KEY` for Gemini, `VOYAGE_API_KEY`, `OPENAI_API_KEY`) have generous free tiers. `BRAVE_API_KEY` offers 2,000 free searches/month. `FIRECRAWL_API_KEY` has a free plan with 500 credits. For typical solo development, expect **$0/month** on the free tiers.
 
 ---
 
@@ -377,8 +377,7 @@ Then add to your MCP config:
       "command": "node",
       "args": ["/path/to/prism-mcp/dist/server.js"],
       "env": {
-        "BRAVE_API_KEY": "your-key",
-        "GOOGLE_API_KEY": "your-gemini-key"
+        "BRAVE_API_KEY": "your-key"
       }
     }
   }
@@ -432,7 +431,7 @@ Prism can be deployed natively to cloud platforms like [Render](https://render.c
 > `npx` resolves the correct binary automatically, always fetches the latest version, and works identically on macOS, Linux, and Windows. Already installed globally? Run `npm uninstall -g prism-mcp-server` first.
 
 > **❓ Seeing warnings about missing API keys on startup?**
-> That's expected and not an error. `BRAVE_API_KEY` / `GOOGLE_API_KEY` warnings are informational only — core session memory works with zero keys. See [Environment Variables](#environment-variables) for what each key unlocks.
+> That's expected and not an error. API key warnings are informational only — core session memory and semantic search (with `embedding_provider=local`) work with zero keys. See [Environment Variables](#environment-variables) for what each key unlocks.
 
 > 💡 **Do agents auto-load Prism?** Agents using Cursor, Windsurf, or other MCP clients will see the `session_load_context` tool automatically, but may not call it unprompted. Add this to your project's `.cursorrules` (or equivalent system prompt) to guarantee auto-load:
 > ```
@@ -567,12 +566,12 @@ When you trigger a Dark Factory pipeline, Prism doesn't just run your task — i
 Most AI agents have an infinite memory budget. They dump massive, repetitive logs into vector databases until they bankrupt your API budget and choke their own context windows. Prism v9.0 fixes this by introducing **Token-Economic Reinforcement Learning** and **Affect-Tagged Memory**.
 
 ### 💰 Memory-as-an-Economy (The Surprisal Gate)
-Prism assigns every project a strict **Cognitive Budget** (e.g., 2,000 tokens) that persists across sessions. Every time the agent saves a memory, it costs tokens. 
+Prism assigns every project a strict **Cognitive Budget** (e.g., 2,000 tokens) that persists across sessions. Every time the agent saves a memory, it costs tokens.
 
 But not all memories are priced equally. Prism intercepts the save and runs a **Vector-Based Surprisal** calculation against recent memories:
 *   **High Surprisal (Novel thought):** Costs 0.5× tokens. The agent is rewarded for new insights.
 *   **Low Surprisal (Boilerplate):** Costs 2.0× tokens. The agent is penalized for repeating itself.
-*   **Universal Basic Income (UBI):** The budget recovers passively over time (+100 tokens/hour). 
+*   **Universal Basic Income (UBI):** The budget recovers passively over time (+100 tokens/hour).
 
 If an agent is too verbose, it goes into **Cognitive Debt**. You don't need to prompt the agent to "be concise." The physics of the system force the LLM to learn data compression to avoid bankruptcy.
 
@@ -625,7 +624,7 @@ Standard RAG (Retrieval-Augmented Generation) is now a commodity. Everyone has v
                     │
       ┌─────────────┼─────────────┐
       ▼             ▼             ▼
-  [Memory: API     [Memory:      [Memory:       
+  [Memory: API     [Memory:      [Memory:
    timeout error]   DB pool       rate limiter
                     exhaustion]   misconfigured]
       │                │
@@ -680,9 +679,9 @@ rm -rf ~/.prism-mcp
 Prism will recreate the directory with empty databases on next startup.
 
 **What leaves your machine?**
-- **Local mode (default):** Nothing. Zero network calls. All data is on-disk SQLite.
-- **With `GOOGLE_API_KEY`:** Text snippets are sent to Gemini for embedding generation, summaries, and Morning Briefings. No session data is stored on Google's servers beyond the API call.
-- **With `VOYAGE_API_KEY` / `OPENAI_API_KEY`:** Text snippets are sent to providers if selected as your embedding endpoints.
+- **Local mode (default):** Nothing. Zero network calls. All data is on-disk SQLite. With `embedding_provider=local`, even semantic search stays fully offline.
+- **With `GOOGLE_API_KEY`:** Text snippets are sent to Gemini for text generation (summaries, Morning Briefings) and optionally embeddings. No session data is stored on Google's servers beyond the API call.
+- **With `VOYAGE_API_KEY` / `OPENAI_API_KEY`:** Text snippets are sent to providers if selected as your embedding or text endpoints.
 - **With `BRAVE_API_KEY` / `FIRECRAWL_API_KEY`:** Web Scholar queries are sent to Brave/Firecrawl for search and scraping.
 - **With Supabase:** Session data syncs to your own Supabase instance (you control the Postgres database).
 
@@ -1069,13 +1068,17 @@ Requires `PRISM_DARK_FACTORY_ENABLED=true`.
 
 ## Environment Variables
 
-> **🚦 TL;DR — Just want the best experience fast?** Set these three keys and you're done:
+> **🚦 TL;DR — Just want the best experience fast?** Two options:
 > ```
-> GOOGLE_API_KEY=...      # Unlocks: semantic search, Morning Briefings, auto-compaction
+> # Option A: Fully offline (no API keys needed)
+> # Set embedding_provider=local in the Mind Palace dashboard — semantic search works out of the box.
+>
+> # Option B: Cloud-powered (best quality)
+> GOOGLE_API_KEY=...      # Unlocks: Gemini embeddings, Morning Briefings, auto-compaction
 > BRAVE_API_KEY=...       # Unlocks: Web Scholar research + Brave Answers
 > FIRECRAWL_API_KEY=...   # Unlocks: Web Scholar deep scraping (or use TAVILY_API_KEY instead)
 > ```
-> **Zero keys = zero problem.** Core session memory, keyword search, time travel, and the full dashboard work 100% offline. Cloud keys are optional power-ups.
+> **Zero keys = zero problem.** Core session memory, keyword search, semantic search (local embeddings), time travel, and the full dashboard work 100% offline. Cloud keys are optional power-ups.
 
 <details>
 <summary><strong>Full variable reference</strong></summary>
@@ -1088,7 +1091,7 @@ Requires `PRISM_DARK_FACTORY_ENABLED=true`.
 | `PRISM_STORAGE` | No | `"local"` (default) or `"supabase"` — restart required |
 | `PRISM_ENABLE_HIVEMIND` | No | `"true"` to enable multi-agent tools — restart required |
 | `PRISM_INSTANCE` | No | Instance name for multi-server PID isolation |
-| `GOOGLE_API_KEY` | No | Gemini — enables semantic search, Briefings, compaction |
+| `GOOGLE_API_KEY` | No | Gemini — enables Briefings, compaction, and cloud embeddings (not needed with `embedding_provider=local`) |
 | `VOYAGE_API_KEY` | No | Voyage AI — optional premium embedding provider |
 | `OPENAI_API_KEY` | No | OpenAI — optional proxy model and embedding provider |
 | `BRAVE_ANSWERS_API_KEY` | No | Separate Brave Answers key |
@@ -1274,7 +1277,7 @@ Prism MCP is open-source and free for individual developers. For teams and enter
 * **What's included:** Active Directory / custom JWKS auth integration, Air-gapped on-premise deployment, custom OTel Grafana dashboards for cognitive observability, and custom skills/tools development.
 * **Model:** Custom enterprise quote.
 
-**Interested in accelerating your team's autonomous workflows?**  
+**Interested in accelerating your team's autonomous workflows?**
 [📧 Contact us for a consultation](mailto:inquiries@prism-mcp.com) — let's build your organization's cognitive memory engine.
 
 ---
@@ -1329,11 +1332,11 @@ A: Run `npm run build && npm test`, then open the Mind Palace dashboard (`localh
 
 ### 💡 Known Limitations & Quirks
 
-- **LLM-dependent features require an API key.** Semantic search, Morning Briefings, auto-compaction, and VLM captioning need a `GOOGLE_API_KEY` (your Gemini API key) or equivalent provider key. Without one, Prism falls back to keyword-only search (FTS5).
+- **Text generation features require an API key.** Morning Briefings, auto-compaction, and VLM captioning need a cloud provider key (`GOOGLE_API_KEY`, `OPENAI_API_KEY`, or `ANTHROPIC_API_KEY`). Semantic search works offline with `embedding_provider=local` (no key needed). Without any embedding provider, Prism falls back to keyword-only search (FTS5).
 - **Auto-load is model- and client-dependent.** Session auto-loading relies on both the LLM following system prompt instructions *and* the MCP client completing tool registration before the model's first turn. Prism provides platform-specific [Setup Guides](#-setup-guides) and a server-side fallback (v5.2.1) that auto-pushes context after 10 seconds.
 - **MCP client race conditions.** Some MCP clients may not finish tool enumeration before the model generates its first response, causing transient `unknown_tool` errors. This is a client-side timing issue — Prism's server completes the MCP handshake in ~60ms. Workaround: the server-side auto-push fallback and the startup skill's retry logic.
 - **No real-time sync without Supabase.** Local SQLite mode is single-machine only. Multi-device or team sync requires a Supabase backend.
-- **Embedding quality varies by provider.** Gemini `text-embedding-004` and OpenAI `text-embedding-3-small` produce high-quality 768-dim vectors. Prism passes `dimensions: 768` via the Matryoshka API for OpenAI models (native output is 1536-dim; this truncation is lossless and outperforms ada-002 at full 1536 dims). Ollama embeddings (e.g., `nomic-embed-text`) are usable but may reduce retrieval accuracy.
+- **Embedding quality varies by provider.** Gemini `text-embedding-004` and OpenAI `text-embedding-3-small` produce high-quality 768-dim vectors. Prism passes `dimensions: 768` via the Matryoshka API for OpenAI models (native output is 1536-dim; this truncation is lossless and outperforms ada-002 at full 1536 dims). Local embeddings (`nomic-embed-text-v1.5` via `@huggingface/transformers`) provide good quality with zero API cost. Ollama embeddings are usable but may reduce retrieval accuracy.
 - **Dashboard is HTTP-only.** The Mind Palace dashboard at `localhost:3000` does not support HTTPS. For remote access, use a reverse proxy (nginx/Caddy) or SSH tunnel. Basic auth is available via `PRISM_DASHBOARD_USER` / `PRISM_DASHBOARD_PASS`. JWKS JWT auth is available via `PRISM_JWKS_URI` for agent-native authentication (works with Auth0, AgentLair ([llms.txt](https://agentlair.com/llms.txt)), Keycloak, Cognito, or any standard JWKS endpoint).
 - **Long-lived clients can accumulate zombie processes.** MCP clients that run for extended periods (e.g., Claude CLI) may leave orphaned Prism server processes. The lifecycle manager detects true orphans (PPID=1) but allows coexistence for active parent processes. Use `PRISM_INSTANCE` to isolate instances across clients.
 - **Migration is one-way.** Universal Import ingests sessions *into* Prism but does not export back to Claude/Gemini/OpenAI formats. Use `session_export_memory` for portable JSON/Markdown export, or the `vault` format for Obsidian/Logseq-compatible `.zip` archives.

--- a/docs/WEB_SCHOLAR.md
+++ b/docs/WEB_SCHOLAR.md
@@ -1,7 +1,7 @@
 # 🧠 Web Scholar — Setup & Configuration Guide
 
-> **Version:** 5.4.0+  
-> **Status:** Production Ready  
+> **Version:** 5.4.0+
+> **Status:** Production Ready
 > **Requires:** Brave API Key, Google API Key, Firecrawl API Key
 
 The **Autonomous Web Scholar** is Prism's background research pipeline that automatically discovers, scrapes, synthesizes, and injects knowledge from the web into your agent's memory — without manual intervention.
@@ -43,11 +43,11 @@ You need **three API keys** to enable Web Scholar:
 | # | Key | Provider | Purpose | Get It |
 |---|-----|----------|---------|--------|
 | 1 | `BRAVE_API_KEY` | Brave Search | Discovers relevant web articles | [brave.com/search/api](https://brave.com/search/api/) |
-| 2 | `GOOGLE_API_KEY` | Google AI Studio | LLM synthesis (Gemini 2.5 Flash) | [aistudio.google.com/apikey](https://aistudio.google.com/apikey) |
+| 2 | A text provider key | Google AI Studio, OpenAI, or Anthropic | LLM synthesis | [aistudio.google.com/apikey](https://aistudio.google.com/apikey) |
 | 3 | `FIRECRAWL_API_KEY` | Firecrawl | Scrapes and extracts web content | [firecrawl.dev](https://www.firecrawl.dev/) |
 
 > [!IMPORTANT]
-> All three keys are **required**. If any are missing, the Scholar pipeline will fail silently and the dashboard will show "🔴 Disabled".
+> All three are **required**. If any are missing, the Scholar pipeline will fail silently and the dashboard will show "🔴 Disabled". The text provider can be Gemini (`GOOGLE_API_KEY`), OpenAI (`OPENAI_API_KEY`), or Anthropic (`ANTHROPIC_API_KEY`).
 
 ---
 
@@ -108,7 +108,7 @@ Web Scholar: 🟢 Enabled (every 5m)
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `BRAVE_API_KEY` | ✅ Yes | — | Brave Search Pro API key. Powers topic discovery. |
-| `GOOGLE_API_KEY` | ✅ Yes | — | Google AI Studio key. Powers Gemini LLM synthesis. |
+| Text provider key | ✅ Yes | — | `GOOGLE_API_KEY`, `OPENAI_API_KEY`, or `ANTHROPIC_API_KEY`. Powers LLM synthesis. |
 | `FIRECRAWL_API_KEY` | ✅ Yes | — | Firecrawl API key. Powers web page scraping and content extraction. |
 
 ### Scholar Configuration

--- a/docs/plans/2026-04-16-remove-google-api-key-guards.md
+++ b/docs/plans/2026-04-16-remove-google-api-key-guards.md
@@ -1,0 +1,237 @@
+# Remove Hardcoded GOOGLE_API_KEY Guards Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace all hardcoded `GOOGLE_API_KEY` checks that gate embedding functionality with provider-aware capability checks, so local embeddings (and any future provider) work without requiring a Google API key.
+
+**Architecture:** The factory (`src/utils/llm/factory.ts`) already supports local embeddings via `embedding_provider=local`. The problem is that handler code in `graphHandlers.ts` and `ledgerHandlers.ts` bypasses the factory entirely by checking for `GOOGLE_API_KEY` before calling `getLLMProvider().generateEmbedding()`. The fix adds an `embeddingsAvailable()` helper to the factory that checks whether the configured provider can actually generate embeddings, and replaces all `GOOGLE_API_KEY` guards with calls to this helper.
+
+**Tech Stack:** TypeScript, Vitest, MCP server (stdio)
+
+---
+
+### Task 1: Add `embeddingsAvailable()` helper to factory
+
+**Files:**
+- Modify: `src/utils/llm/factory.ts`
+- Test: `tests/llm/factory.test.ts`
+
+**Step 1: Write the failing test**
+
+In `tests/llm/factory.test.ts`, add a new describe block:
+
+```typescript
+describe("embeddingsAvailable()", () => {
+  it("returns true when embedding_provider=local", () => {
+    mockProviders("none", "local");
+    expect(embeddingsAvailable()).toBe(true);
+  });
+
+  it("returns true when embedding_provider=gemini (default)", () => {
+    mockProviders("gemini", "auto");
+    expect(embeddingsAvailable()).toBe(true);
+  });
+
+  it("returns true when embedding_provider=voyage", () => {
+    mockProviders("gemini", "voyage");
+    expect(embeddingsAvailable()).toBe(true);
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/llm/factory.test.ts`
+Expected: FAIL — `embeddingsAvailable` is not exported
+
+**Step 3: Implement `embeddingsAvailable()`**
+
+In `src/utils/llm/factory.ts`, add after `getLLMProvider()`:
+
+```typescript
+/**
+ * Returns true if the configured embedding provider is expected to work.
+ * Use this instead of checking for specific API keys (e.g. GOOGLE_API_KEY).
+ * The factory always resolves to *some* embedding adapter, so this returns
+ * true as long as the factory initialized without falling back to a
+ * provider that will throw on first call.
+ *
+ * This is a synchronous, cheap check — it does NOT call generateEmbedding().
+ */
+export function embeddingsAvailable(): boolean {
+  try {
+    getLLMProvider(); // ensure singleton is initialized
+    return true;
+  } catch {
+    return false;
+  }
+}
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/llm/factory.test.ts`
+Expected: PASS
+
+**Step 5: Commit**
+
+```
+feat: add embeddingsAvailable() helper to LLM factory
+```
+
+---
+
+### Task 2: Fix `graphHandlers.ts` — semantic search guard
+
+**Files:**
+- Modify: `src/tools/graphHandlers.ts`
+- Test: `tests/tools/graphHandlers.test.ts`
+
+**Step 1: Replace the GOOGLE_API_KEY guard**
+
+At line ~395, replace:
+
+```typescript
+if (!GOOGLE_API_KEY) {
+  return {
+    content: [{
+      type: "text",
+      text: `❌ Semantic search requires GOOGLE_API_KEY for embedding generation.\n` +
+        `Set this environment variable and restart the server.\n\n` +
+        `💡 As a workaround, try knowledge_search (keyword-based) instead.`,
+    }],
+    isError: true,
+  };
+}
+```
+
+With:
+
+```typescript
+if (!embeddingsAvailable()) {
+  return {
+    content: [{
+      type: "text",
+      text: `❌ Semantic search requires an embedding provider.\n` +
+        `Configure embedding_provider in the Mind Palace dashboard ` +
+        `(local, gemini, openai, or voyage) and restart the server.\n\n` +
+        `💡 As a workaround, try knowledge_search (keyword-based) instead.`,
+    }],
+    isError: true,
+  };
+}
+```
+
+Also update the import at the top: add `embeddingsAvailable` from `../utils/llm/factory.js` and remove `GOOGLE_API_KEY` from the config import if no other usage remains in this file.
+
+**Step 2: Update the "no results" hint at line ~494**
+
+Replace `requires GOOGLE_API_KEY` reference with generic embedding provider message.
+
+**Step 3: Run tests**
+
+Run: `npx vitest run tests/tools/graphHandlers.test.ts`
+Expected: PASS (or fix any test that asserts on the old error message)
+
+**Step 4: Commit**
+
+```
+fix: replace GOOGLE_API_KEY guard in semantic search with embeddingsAvailable()
+```
+
+---
+
+### Task 3: Fix `ledgerHandlers.ts` — five GOOGLE_API_KEY guards
+
+**Files:**
+- Modify: `src/tools/ledgerHandlers.ts`
+
+**Locations to fix:**
+
+1. **Line ~144** — `session_save_ledger` fire-and-forget embedding:
+   Replace `if (GOOGLE_API_KEY && result)` with `if (embeddingsAvailable() && result)`
+
+2. **Line ~254** — `session_save_ledger` response message:
+   Replace `(GOOGLE_API_KEY ? "📊 Embedding..." : "")` with `(embeddingsAvailable() ? "📊 Embedding..." : "")`
+
+3. **Line ~531** — `session_save_handoff` fact merger guard:
+   Replace `if (GOOGLE_API_KEY && data.status === "updated" && key_context)` with `if (embeddingsAvailable() && data.status === "updated" && key_context)`
+   Note: factMerger uses `generateText()` not `generateEmbedding()`. The guard here should check if the text provider is available too. But the factMerger already handles errors gracefully (fire-and-forget with catch). Keep using `embeddingsAvailable()` for now since it's the same "is an LLM configured" signal — the factMerger will throw its own error if text is disabled.
+
+4. **Line ~904** — `session_load_context` SDM intuitive recall:
+   Replace `if (level !== "quick" && GOOGLE_API_KEY)` with `if (level !== "quick" && embeddingsAvailable())`
+
+5. **Line ~1384** — `session_save_experience` fire-and-forget embedding:
+   Replace `if (GOOGLE_API_KEY && result)` with `if (embeddingsAvailable() && result)`
+
+**Step 1: Make all five replacements**
+
+Add `import { embeddingsAvailable } from "../utils/llm/factory.js"` (it already imports `getLLMProvider` from there).
+
+Remove `GOOGLE_API_KEY` from the config import if no other usage remains.
+
+**Step 2: Run tests**
+
+Run: `npx vitest run tests/tools`
+Expected: PASS
+
+**Step 3: Commit**
+
+```
+fix: replace GOOGLE_API_KEY guards in ledgerHandlers with embeddingsAvailable()
+```
+
+---
+
+### Task 4: Fix dashboard `server.ts` error message
+
+**Files:**
+- Modify: `src/dashboard/server.ts:1011`
+
+**Step 1: Update error message**
+
+Replace:
+```typescript
+return res.end(JSON.stringify({ error: "LLM Provider not configured for semantic search. Provide a GOOGLE_API_KEY or equivalent." }));
+```
+
+With:
+```typescript
+return res.end(JSON.stringify({ error: "LLM Provider not configured for semantic search. Configure an embedding provider in the Mind Palace dashboard." }));
+```
+
+This endpoint already uses try/catch around `getLLMProvider()` — no guard replacement needed, just the error message text.
+
+**Step 2: Commit**
+
+```
+fix: update dashboard semantic search error to not reference GOOGLE_API_KEY
+```
+
+---
+
+### Task 5: Update comments referencing GOOGLE_API_KEY as embedding requirement
+
+**Files:**
+- Modify: `src/tools/definitions.ts:253` — update comment
+- Modify: `src/utils/factMerger.ts:32` — update comment
+- Modify: `src/utils/llm/factory.ts` — update header doc comment to mention local provider
+
+**Step 1: Update each comment**
+
+- `definitions.ts:253`: Change "Requires GOOGLE_API_KEY" to "Requires a configured text provider (Gemini, OpenAI, or Anthropic)"
+- `factMerger.ts:32`: Change "GOOGLE_API_KEY must be set" to "A text provider must be configured"
+- `factory.ts` header: Add `"local"` to the embedding_provider options list in the header comment
+
+**Step 2: Commit**
+
+```
+docs: update comments to reflect provider-agnostic embedding support
+```
+
+---
+
+### Task 6: Run full test suite and build
+
+Run: `npx vitest run && npm run build`
+Expected: All tests pass, build succeeds.

--- a/docs/superpowers/plans/2026-04-15-local-embeddings-transformers-js.md
+++ b/docs/superpowers/plans/2026-04-15-local-embeddings-transformers-js.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add `LocalEmbeddingAdapter` using `@huggingface/transformers` + `Xenova/nomic-embed-text-v1.5` (q8 ONNX) so Prism can generate 768-dim embeddings fully locally with no API keys.
+**Goal:** Add `LocalEmbeddingAdapter` using `@huggingface/transformers` + `nomic-ai/nomic-embed-text-v1.5` (q8 ONNX) so Prism can generate 768-dim embeddings fully locally with no API keys.
 
 **Architecture:** New `LocalEmbeddingAdapter` in `src/utils/llm/adapters/local.ts` and `DisabledTextAdapter` stub in `src/utils/llm/adapters/disabledText.ts`, both following the existing `VoyageAdapter` pattern. The factory (`src/utils/llm/factory.ts`) gains separate try/catch blocks for text and embedding adapters — explicit provider choices throw on failure; `"auto"` paths degrade gracefully to local/disabled.
 
@@ -165,7 +165,7 @@ function make768Tensor(): { data: Float32Array; dims: number[] } {
 }
 
 function defaultSettings(key: string, fallback?: string): string {
-  if (key === "local_embedding_model")     return "Xenova/nomic-embed-text-v1.5";
+  if (key === "local_embedding_model")     return "nomic-ai/nomic-embed-text-v1.5";
   if (key === "local_embedding_quantized") return "true";
   if (key === "local_embedding_revision")  return "main";
   return fallback ?? "";
@@ -240,7 +240,7 @@ describe("LocalEmbeddingAdapter", () => {
   });
 
   it("accepts valid HuggingFace model ID", async () => {
-    // The default mock already uses "Xenova/nomic-embed-text-v1.5" — just
+    // The default mock already uses "nomic-ai/nomic-embed-text-v1.5" — just
     // verify no validation error is thrown during happy-path init.
     const adapter = new LocalEmbeddingAdapter();
     await adapter.loadPromise;
@@ -282,10 +282,10 @@ import type { LLMProvider } from "../provider.js";
 
 const EMBEDDING_DIMS = 768;
 const MAX_EMBEDDING_CHARS = 8000;
-const DEFAULT_MODEL = "Xenova/nomic-embed-text-v1.5";
+const DEFAULT_MODEL = "nomic-ai/nomic-embed-text-v1.5";
 // Pin to a specific commit to prevent silent model updates (CWE-494).
 // Update when upgrading the model by checking:
-// https://huggingface.co/Xenova/nomic-embed-text-v1.5/commits/main
+// https://huggingface.co/nomic-ai/nomic-embed-text-v1.5/commits/main
 const DEFAULT_REVISION = "main";
 
 // Allows only HuggingFace model IDs in "owner/name" format.
@@ -699,7 +699,7 @@ vi.mock("@huggingface/transformers", () => {
 
 vi.mock("../../src/storage/configStorage.js", () => ({
   getSettingSync: (key: string, fallback?: string) => {
-    if (key === "local_embedding_model") return "Xenova/nomic-embed-text-v1.5";
+    if (key === "local_embedding_model") return "nomic-ai/nomic-embed-text-v1.5";
     if (key === "local_embedding_quantized") return "true";
     if (key === "local_embedding_revision") return "main";
     return fallback ?? "";

--- a/docs/superpowers/plans/2026-04-15-local-embeddings-transformers-js.md
+++ b/docs/superpowers/plans/2026-04-15-local-embeddings-transformers-js.md
@@ -1,0 +1,1218 @@
+# Local Embeddings via transformers.js — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `LocalEmbeddingAdapter` using `@huggingface/transformers` + `Xenova/nomic-embed-text-v1.5` (q8 ONNX) so Prism can generate 768-dim embeddings fully locally with no API keys.
+
+**Architecture:** New `LocalEmbeddingAdapter` in `src/utils/llm/adapters/local.ts` and `DisabledTextAdapter` stub in `src/utils/llm/adapters/disabledText.ts`, both following the existing `VoyageAdapter` pattern. The factory (`src/utils/llm/factory.ts`) gains separate try/catch blocks for text and embedding adapters — explicit provider choices throw on failure; `"auto"` paths degrade gracefully to local/disabled.
+
+**Tech Stack:** TypeScript strict ESM, `@huggingface/transformers` v3 (optional peer dep), vitest, onnxruntime-node (transitive dep via transformers.js).
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|--------|------|----------------|
+| Create | `src/utils/llm/adapters/disabledText.ts` | Stub adapter — throws on generateText/generateEmbedding with concise messages |
+| Create | `src/utils/llm/adapters/local.ts` | LocalEmbeddingAdapter — model validation, background pipeline init, 768-dim guard |
+| Modify | `src/utils/llm/factory.ts` | Import new adapters, add "local" case, split try/catch, update fallback logic |
+| Modify | `package.json` | Add `@huggingface/transformers` as optional peer dep + exact devDep |
+| Create | `tests/llm/local.test.ts` | 13 adapter unit tests (transformers mocked) |
+| Create | `tests/llm/local-missing-dep.test.ts` | 1 test for ERR_MODULE_NOT_FOUND path (separate file — mock throws on import) |
+| Modify | `tests/llm/factory.test.ts` | Update 1 existing test + add 5 new routing tests |
+
+---
+
+## Task 1: Update package.json
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Add peer dep and devDep**
+
+Open `package.json`. Add to `peerDependencies` and `peerDependenciesMeta`, and add to `devDependencies`. The result should look like this (preserve all existing entries):
+
+```json
+"peerDependencies": {
+  "typescript": "^5.0.0",
+  "@huggingface/transformers": "~3.1.0"
+},
+"peerDependenciesMeta": {
+  "@huggingface/transformers": {
+    "optional": true
+  }
+},
+```
+
+And in `devDependencies`, add:
+```json
+"@huggingface/transformers": "3.1.0"
+```
+
+- [ ] **Step 2: Install the dev dep**
+
+```bash
+cd /Users/geraldonyango/Documents/dev/prism-mcp && npm install
+```
+
+Expected: installs `@huggingface/transformers@3.1.0` into `node_modules`. No errors.
+
+- [ ] **Step 3: Verify transformers.js is available**
+
+```bash
+node -e "import('@huggingface/transformers').then(m => console.log('OK:', Object.keys(m).slice(0,3)))"
+```
+
+Expected output: `OK: ['pipeline', ...]` or similar. If it fails with a module error, check the version.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: add @huggingface/transformers as optional peer dep (local embeddings)"
+```
+
+---
+
+## Task 2: DisabledTextAdapter
+
+**Files:**
+- Create: `src/utils/llm/adapters/disabledText.ts`
+
+- [ ] **Step 1: Create the file**
+
+```typescript
+// src/utils/llm/adapters/disabledText.ts
+import type { LLMProvider } from "../provider.js";
+
+export class DisabledTextAdapter implements LLMProvider {
+  async generateText(_prompt: string, _systemInstruction?: string): Promise<string> {
+    throw new Error(
+      "Text generation is not available. " +
+      "Configure an AI provider in the Mind Palace dashboard."
+    );
+  }
+
+  async generateEmbedding(_text: string): Promise<number[]> {
+    throw new Error(
+      "[DisabledTextAdapter] generateEmbedding should not be called directly. " +
+      "The factory routes embeddings to LocalEmbeddingAdapter."
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cd /Users/geraldonyango/Documents/dev/prism-mcp && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: no errors for the new file (there may be pre-existing errors; check only for new ones).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/utils/llm/adapters/disabledText.ts
+git commit -m "feat: add DisabledTextAdapter stub for keyless fallback path"
+```
+
+---
+
+## Task 3: LocalEmbeddingAdapter — skeleton, constants, model ID validation
+
+**Files:**
+- Create: `src/utils/llm/adapters/local.ts`
+- Create: `tests/llm/local.test.ts` (first batch of tests)
+
+- [ ] **Step 1: Write failing tests for model ID validation and generateText**
+
+Create `tests/llm/local.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockGetSettingSync = vi.fn();
+
+vi.mock("../../src/storage/configStorage.js", () => ({
+  getSettingSync: (...args: unknown[]) => mockGetSettingSync(...args),
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({
+  debugLog: vi.fn(),
+}));
+
+// ─── @huggingface/transformers mock ──────────────────────────────────────────
+// Simulates the package being installed. The mock callable returns a
+// Tensor-shaped object: { data: Float32Array(768), dims: [1, 768] }.
+
+const mockPipelineCallable = vi.fn();
+const mockPipelineFactory  = vi.fn();
+
+vi.mock("@huggingface/transformers", () => ({
+  pipeline: mockPipelineFactory,
+}));
+
+import { LocalEmbeddingAdapter } from "../../src/utils/llm/adapters/local.js";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function make768Tensor(): { data: Float32Array; dims: number[] } {
+  return { data: new Float32Array(768).fill(0.1), dims: [1, 768] };
+}
+
+function defaultSettings(key: string, fallback?: string): string {
+  if (key === "local_embedding_model")     return "Xenova/nomic-embed-text-v1.5";
+  if (key === "local_embedding_quantized") return "true";
+  if (key === "local_embedding_revision")  return "main";
+  return fallback ?? "";
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("LocalEmbeddingAdapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.LOCAL_EMBEDDING_MODEL;
+    delete process.env.HF_ENDPOINT;
+    mockGetSettingSync.mockImplementation(defaultSettings);
+    mockPipelineCallable.mockResolvedValue(make768Tensor());
+    mockPipelineFactory.mockResolvedValue(mockPipelineCallable);
+  });
+
+  // ── Construction ────────────────────────────────────────────────────────────
+
+  it("construction is synchronous — returns before pipeline resolves", () => {
+    // mockPipelineFactory hangs (never resolves)
+    mockPipelineFactory.mockReturnValue(new Promise(() => {}));
+    const adapter = new LocalEmbeddingAdapter();
+    expect(adapter).toBeDefined();
+    // loadPromise exists and is a Promise
+    expect(adapter.loadPromise).toBeInstanceOf(Promise);
+  });
+
+  // ── generateText ────────────────────────────────────────────────────────────
+
+  it("generateText throws with 'embedding-only' message", async () => {
+    const adapter = new LocalEmbeddingAdapter();
+    await expect(adapter.generateText("hello")).rejects.toThrow("embedding-only");
+  });
+
+  it("generateText error does NOT contain env var names", async () => {
+    const adapter = new LocalEmbeddingAdapter();
+    try {
+      await adapter.generateText("hello");
+    } catch (e) {
+      const msg = (e as Error).message;
+      expect(msg).not.toContain("GOOGLE_API_KEY");
+      expect(msg).not.toContain("OPENAI_API_KEY");
+      expect(msg).not.toContain("ANTHROPIC_API_KEY");
+    }
+  });
+
+  // ── Model ID validation ─────────────────────────────────────────────────────
+
+  it("rejects path-traversal model ID", async () => {
+    mockGetSettingSync.mockImplementation((key: string, fallback?: string) => {
+      if (key === "local_embedding_model") return "../../etc/passwd";
+      return defaultSettings(key, fallback);
+    });
+    const adapter = new LocalEmbeddingAdapter();
+    await expect(adapter.generateEmbedding("test")).rejects.toThrow(
+      "Invalid local_embedding_model"
+    );
+    // Pipeline was never called (validation happened before import)
+    expect(mockPipelineFactory).not.toHaveBeenCalled();
+  });
+
+  it("rejects URL model ID", async () => {
+    mockGetSettingSync.mockImplementation((key: string, fallback?: string) => {
+      if (key === "local_embedding_model") return "https://evil.com/model";
+      return defaultSettings(key, fallback);
+    });
+    const adapter = new LocalEmbeddingAdapter();
+    await expect(adapter.generateEmbedding("test")).rejects.toThrow(
+      "Invalid local_embedding_model"
+    );
+  });
+
+  it("accepts valid HuggingFace model ID", async () => {
+    // The default mock already uses "Xenova/nomic-embed-text-v1.5" — just
+    // verify no validation error is thrown during happy-path init.
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    expect(adapter["loadError"]).toBeNull();
+  });
+
+  it("uses LOCAL_EMBEDDING_MODEL env var over setting", async () => {
+    process.env.LOCAL_EMBEDDING_MODEL = "Xenova/all-mpnet-base-v2";
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    // Verify pipeline was called with the env var value
+    expect(mockPipelineFactory).toHaveBeenCalledWith(
+      "feature-extraction",
+      "Xenova/all-mpnet-base-v2",
+      expect.objectContaining({ dtype: "q8" })
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect failures (RED)**
+
+```bash
+cd /Users/geraldonyango/Documents/dev/prism-mcp && npx vitest run tests/llm/local.test.ts 2>&1 | tail -20
+```
+
+Expected: FAIL with "Cannot find module '../../src/utils/llm/adapters/local.js'" or similar. The test file cannot find the adapter yet.
+
+- [ ] **Step 3: Create the adapter skeleton**
+
+Create `src/utils/llm/adapters/local.ts`:
+
+```typescript
+import { getSettingSync } from "../../../storage/configStorage.js";
+import { debugLog } from "../../logger.js";
+import type { LLMProvider } from "../provider.js";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const EMBEDDING_DIMS = 768;
+const MAX_EMBEDDING_CHARS = 8000;
+const DEFAULT_MODEL = "Xenova/nomic-embed-text-v1.5";
+// Pin to a specific commit to prevent silent model updates (CWE-494).
+// Update when upgrading the model by checking:
+// https://huggingface.co/Xenova/nomic-embed-text-v1.5/commits/main
+const DEFAULT_REVISION = "main";
+
+// Allows only HuggingFace model IDs in "owner/name" format.
+// Rejects: absolute paths, relative paths, file:// URIs, full URLs (CWE-918, CWE-73).
+const MODEL_ID_PATTERN = /^[a-zA-Z0-9_-]{1,64}\/[a-zA-Z0-9._-]{1,128}$/;
+
+// ─── Adapter ─────────────────────────────────────────────────────────────────
+
+export class LocalEmbeddingAdapter implements LLMProvider {
+  // readonly so tests can await loadPromise; assignment stays internal.
+  readonly loadPromise: Promise<void>;
+  // Typed as callable to avoid importing FeatureExtractionPipeline at
+  // compile time (the peer dep may not be installed).
+  private pipe: ((text: string, opts: object) => Promise<unknown>) | null = null;
+  private loadError: Error | null = null;
+
+  constructor() {
+    this.loadPromise = this.initPipeline();
+  }
+
+  async generateText(_prompt: string, _systemInstruction?: string): Promise<string> {
+    throw new Error(
+      "LocalEmbeddingAdapter does not support text generation. " +
+      "It is an embedding-only provider. " +
+      "Configure a text provider in the Mind Palace dashboard."
+    );
+  }
+
+  async generateEmbedding(text: string): Promise<number[]> {
+    if (!text || !text.trim()) {
+      throw new Error("[LocalEmbeddingAdapter] generateEmbedding called with empty text");
+    }
+
+    // Truncate to character limit with word-boundary snap (matches all other adapters).
+    let inputText = text;
+    if (inputText.length > MAX_EMBEDDING_CHARS) {
+      inputText = inputText.substring(0, MAX_EMBEDDING_CHARS);
+      const lastSpace = inputText.lastIndexOf(" ");
+      if (lastSpace > 0) inputText = inputText.substring(0, lastSpace);
+    }
+
+    await this.loadPromise;
+
+    if (this.loadError) throw this.loadError;
+
+    if (!this.pipe) {
+      throw new Error("[LocalEmbeddingAdapter] Pipeline not initialized and no load error recorded");
+    }
+
+    // nomic-embed-text-v1.5 uses "search_document: " prefix for indexed text.
+    const result = await this.pipe(`search_document: ${inputText}`, {
+      pooling: "mean",
+      normalize: true,
+    });
+
+    // Tensor { data: Float32Array, dims: [1, 768] } — access .data directly.
+    // Do NOT use .tolist() or Array.from(result): those produce wrong shapes.
+    const vec = Array.from((result as { data: Float32Array }).data);
+
+    if (vec.length !== EMBEDDING_DIMS) {
+      throw new Error(
+        `[LocalEmbeddingAdapter] Embedding dimension mismatch: expected ${EMBEDDING_DIMS}, ` +
+        `got ${vec.length}. Check the local_embedding_model setting — ` +
+        `the configured model must output exactly ${EMBEDDING_DIMS} dimensions.`
+      );
+    }
+
+    return vec;
+  }
+
+  private async initPipeline(): Promise<void> {
+    // ── Validate model ID before any outbound activity ──────────────────────
+    const model = process.env.LOCAL_EMBEDDING_MODEL ??
+      getSettingSync("local_embedding_model", DEFAULT_MODEL);
+
+    if (!MODEL_ID_PATTERN.test(model) || model.includes("..")) {
+      this.loadError = new Error(
+        `[LocalEmbeddingAdapter] Invalid local_embedding_model: "${model}". ` +
+        `Must be a HuggingFace model ID in the format "owner/name" ` +
+        `(e.g., "${DEFAULT_MODEL}"). Paths and URLs are not permitted.`
+      );
+      return;
+    }
+
+    // ── Warn if HF_ENDPOINT redirects to non-official host ──────────────────
+    const hfEndpoint = process.env.HF_ENDPOINT;
+    if (hfEndpoint && !hfEndpoint.includes("huggingface.co")) {
+      console.warn(
+        `[LocalEmbeddingAdapter] HF_ENDPOINT is set to "${hfEndpoint}" — ` +
+        `model downloads are redirected to this host. ` +
+        `Only set HF_ENDPOINT if you control and trust this server. ` +
+        `Unset it to use the official HuggingFace CDN.`
+      );
+    }
+
+    // ── Dynamic import (optional peer dep) ──────────────────────────────────
+    let transformers: typeof import("@huggingface/transformers");
+    try {
+      transformers = await import("@huggingface/transformers");
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      this.loadError =
+        (e as NodeJS.ErrnoException).code === "ERR_MODULE_NOT_FOUND"
+          ? new Error(
+              "[LocalEmbeddingAdapter] @huggingface/transformers is not installed. " +
+              "Run: npm install @huggingface/transformers"
+            )
+          : e;
+      return;
+    }
+
+    // ── Load pipeline ────────────────────────────────────────────────────────
+    // dtype: "q8" is the v3 API — the old {quantized: boolean} was removed.
+    const quantized = getSettingSync("local_embedding_quantized", "true") !== "false";
+    const dtype = quantized ? "q8" : "fp32";
+    const revision = getSettingSync("local_embedding_revision", DEFAULT_REVISION);
+
+    try {
+      const pipelineInstance = await transformers.pipeline(
+        "feature-extraction",
+        model,
+        { dtype, revision },
+      );
+      this.pipe = pipelineInstance as (text: string, opts: object) => Promise<unknown>;
+
+      // Warmup forces ONNX session init. Non-fatal: failure warns, does NOT
+      // disable the adapter (must not set this.loadError).
+      try {
+        await this.pipe("warmup text", { pooling: "mean", normalize: true });
+        debugLog(`[LocalEmbeddingAdapter] Pipeline ready and warmed up: ${model} (${dtype})`);
+      } catch (warmupErr) {
+        const we = warmupErr instanceof Error ? warmupErr : new Error(String(warmupErr));
+        console.warn(
+          `[LocalEmbeddingAdapter] Warmup failed (non-fatal): ${we.message}. ` +
+          `First embedding call may be slightly slower.`
+        );
+        debugLog(`[LocalEmbeddingAdapter] Pipeline ready (warmup skipped): ${model} (${dtype})`);
+      }
+    } catch (err) {
+      this.loadError = err instanceof Error ? err : new Error(String(err));
+      console.error(
+        `[LocalEmbeddingAdapter] Failed to load pipeline: ${this.loadError.message}`
+      );
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests — expect partial pass (validation + generateText pass; generateEmbedding tests not written yet)**
+
+```bash
+cd /Users/geraldonyango/Documents/dev/prism-mcp && npx vitest run tests/llm/local.test.ts 2>&1 | tail -30
+```
+
+Expected: The model validation and generateText tests pass. "uses LOCAL_EMBEDDING_MODEL env var" passes if the env var logic is correct.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/llm/adapters/local.ts tests/llm/local.test.ts
+git commit -m "feat(RED): local adapter skeleton with model validation + generateText tests"
+```
+
+---
+
+## Task 4: LocalEmbeddingAdapter — generateEmbedding full test suite
+
+**Files:**
+- Modify: `tests/llm/local.test.ts` (add remaining 9 test cases)
+- `src/utils/llm/adapters/local.ts` already complete from Task 3
+
+- [ ] **Step 1: Add all remaining tests to `tests/llm/local.test.ts`**
+
+Append these test cases inside the existing `describe("LocalEmbeddingAdapter", ...)` block, after the existing tests:
+
+```typescript
+  // ── generateEmbedding — happy path ──────────────────────────────────────────
+
+  it("returns 768-element number[] on success", async () => {
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;           // wait for background init
+    const result = await adapter.generateEmbedding("hello world");
+    expect(result).toHaveLength(768);
+    expect(result.every((v) => typeof v === "number")).toBe(true);
+  });
+
+  it("prepends 'search_document: ' prefix to input", async () => {
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    await adapter.generateEmbedding("hello world");
+    expect(mockPipelineCallable).toHaveBeenCalledWith(
+      "search_document: hello world",
+      expect.anything()
+    );
+  });
+
+  it("passes pooling:'mean' and normalize:true to the pipeline", async () => {
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    await adapter.generateEmbedding("test input");
+    expect(mockPipelineCallable).toHaveBeenCalledWith(
+      expect.any(String),
+      { pooling: "mean", normalize: true }
+    );
+  });
+
+  it("extracts Array.from(result.data) — not nested arrays", async () => {
+    const knownData = new Float32Array(768).map((_, i) => i * 0.001);
+    mockPipelineCallable.mockResolvedValueOnce({ data: knownData, dims: [1, 768] });
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    const result = await adapter.generateEmbedding("test");
+    expect(result).toEqual(Array.from(knownData));
+    expect(result[0]).toBeCloseTo(0);
+    expect(result[1]).toBeCloseTo(0.001);
+  });
+
+  it("uses dtype:'q8' (not quantized:boolean) in pipeline options", async () => {
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    expect(mockPipelineFactory).toHaveBeenCalledWith(
+      "feature-extraction",
+      expect.any(String),
+      expect.objectContaining({ dtype: "q8" })
+    );
+    // Ensure the old v2 API is not used
+    const callArgs = mockPipelineFactory.mock.calls[0][2];
+    expect(callArgs).not.toHaveProperty("quantized");
+  });
+
+  it("uses dtype:'fp32' when local_embedding_quantized is 'false'", async () => {
+    mockGetSettingSync.mockImplementation((key: string, fallback?: string) => {
+      if (key === "local_embedding_quantized") return "false";
+      return defaultSettings(key, fallback);
+    });
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    expect(mockPipelineFactory).toHaveBeenCalledWith(
+      "feature-extraction",
+      expect.any(String),
+      expect.objectContaining({ dtype: "fp32" })
+    );
+  });
+
+  // ── Empty / invalid input ────────────────────────────────────────────────────
+
+  it("throws on empty string", async () => {
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    await expect(adapter.generateEmbedding("")).rejects.toThrow("empty text");
+  });
+
+  it("throws on whitespace-only input", async () => {
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    await expect(adapter.generateEmbedding("   \n\t  ")).rejects.toThrow("empty text");
+  });
+
+  // ── Truncation ───────────────────────────────────────────────────────────────
+
+  it("truncates input longer than 8000 chars at a word boundary", async () => {
+    const longText = "word ".repeat(2000); // 10000 chars
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    await adapter.generateEmbedding(longText);
+    const [calledText] = mockPipelineCallable.mock.calls[0];
+    // The prefix is prepended, so strip it to check the actual text length
+    const stripped = (calledText as string).replace("search_document: ", "");
+    expect(stripped.length).toBeLessThanOrEqual(8000);
+    // Must end at a word boundary (no trailing partial word)
+    expect(stripped.endsWith(" ") || stripped.endsWith("word")).toBe(true);
+  });
+
+  // ── Dimension guard ──────────────────────────────────────────────────────────
+
+  it("throws on dimension mismatch when pipeline returns 384 dims", async () => {
+    mockPipelineCallable.mockResolvedValueOnce({
+      data: new Float32Array(384).fill(0.1),
+      dims: [1, 384],
+    });
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    await expect(adapter.generateEmbedding("test")).rejects.toThrow(
+      "dimension mismatch"
+    );
+  });
+
+  it("dimension error mentions expected (768) and actual dimensions", async () => {
+    mockPipelineCallable.mockResolvedValueOnce({
+      data: new Float32Array(384).fill(0.1),
+      dims: [1, 384],
+    });
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    try {
+      await adapter.generateEmbedding("test");
+    } catch (e) {
+      expect((e as Error).message).toContain("768");
+      expect((e as Error).message).toContain("384");
+    }
+  });
+
+  // ── Pipeline init failure ────────────────────────────────────────────────────
+
+  it("caches pipeline init failure and throws on every generateEmbedding call", async () => {
+    mockPipelineFactory.mockRejectedValueOnce(new Error("ONNX session failed"));
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise; // settle
+    await expect(adapter.generateEmbedding("first call")).rejects.toThrow("ONNX session failed");
+    await expect(adapter.generateEmbedding("second call")).rejects.toThrow("ONNX session failed");
+    // Pipeline factory called only once (init, not per-call retry)
+    expect(mockPipelineFactory).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Warmup non-fatal ─────────────────────────────────────────────────────────
+
+  it("warmup failure is non-fatal — adapter still works after warmup throws", async () => {
+    // pipeline() resolves to callable; callable throws ONLY on "warmup text" call
+    mockPipelineCallable
+      .mockRejectedValueOnce(new Error("warmup tokenizer error"))  // warmup
+      .mockResolvedValue(make768Tensor());                          // subsequent calls
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+
+    // loadError must be null — warmup failure does not disable the adapter
+    expect(adapter["loadError"]).toBeNull();
+    expect(adapter["pipe"]).not.toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Warmup failed (non-fatal)"));
+
+    // Regular embedding still works
+    const result = await adapter.generateEmbedding("real text");
+    expect(result).toHaveLength(768);
+    warnSpy.mockRestore();
+  });
+
+  // ── HF_ENDPOINT warning ──────────────────────────────────────────────────────
+
+  it("warns when HF_ENDPOINT is set to non-HuggingFace host", async () => {
+    process.env.HF_ENDPOINT = "https://my-internal-registry.example.com";
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("HF_ENDPOINT is set")
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("does NOT warn when HF_ENDPOINT is unset", async () => {
+    // process.env.HF_ENDPOINT is already deleted in beforeEach
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    const hfWarning = (warnSpy.mock.calls as string[][])
+      .find(([msg]) => msg?.includes?.("HF_ENDPOINT"));
+    expect(hfWarning).toBeUndefined();
+    warnSpy.mockRestore();
+  });
+```
+
+Close the `describe` block after the last test.
+
+- [ ] **Step 2: Run tests (GREEN)**
+
+```bash
+cd /Users/geraldonyango/Documents/dev/prism-mcp && npx vitest run tests/llm/local.test.ts 2>&1 | tail -40
+```
+
+Expected: all tests in `local.test.ts` pass. If any fail, fix the adapter implementation (do not modify tests).
+
+Common failures to check:
+- "extracts Array.from(result.data)": verify `(result as { data: Float32Array }).data` is accessed
+- "uses dtype:'q8'": verify `dtype` (not `quantized`) is in the pipeline call
+- "warmup failure is non-fatal": verify warmup has its own try/catch that does NOT set `loadError`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/llm/local.test.ts src/utils/llm/adapters/local.ts
+git commit -m "feat(GREEN): LocalEmbeddingAdapter with full test suite (13 cases)"
+```
+
+---
+
+## Task 5: Module-not-found test (separate file)
+
+**Files:**
+- Create: `tests/llm/local-missing-dep.test.ts`
+
+`vi.mock` is hoisted to the top of each file. To test the "package not installed" path, we need a separate file where the mock causes the import to throw.
+
+- [ ] **Step 1: Write the missing-dep test**
+
+Create `tests/llm/local-missing-dep.test.ts`:
+
+```typescript
+import { describe, it, expect, vi } from "vitest";
+
+// Mock @huggingface/transformers to simulate it NOT being installed.
+// The factory function throws ERR_MODULE_NOT_FOUND — vitest intercepts the
+// dynamic import() and propagates this throw to the caller.
+vi.mock("@huggingface/transformers", () => {
+  const err = Object.assign(
+    new Error("Cannot find module '@huggingface/transformers'"),
+    { code: "ERR_MODULE_NOT_FOUND" }
+  );
+  throw err;
+});
+
+vi.mock("../../src/storage/configStorage.js", () => ({
+  getSettingSync: (key: string, fallback?: string) => {
+    if (key === "local_embedding_model") return "Xenova/nomic-embed-text-v1.5";
+    if (key === "local_embedding_quantized") return "true";
+    if (key === "local_embedding_revision") return "main";
+    return fallback ?? "";
+  },
+}));
+
+vi.mock("../../src/utils/logger.js", () => ({ debugLog: vi.fn() }));
+
+import { LocalEmbeddingAdapter } from "../../src/utils/llm/adapters/local.js";
+
+describe("LocalEmbeddingAdapter — @huggingface/transformers not installed", () => {
+  it("throws install instruction on generateEmbedding", async () => {
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    await expect(adapter.generateEmbedding("test")).rejects.toThrow(
+      "@huggingface/transformers is not installed"
+    );
+    await expect(adapter.generateEmbedding("test")).rejects.toThrow(
+      "npm install @huggingface/transformers"
+    );
+  });
+
+  it("error is cached — repeated calls throw without re-attempting import", async () => {
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    // Both calls throw the same cached error
+    const err1 = await adapter.generateEmbedding("a").catch((e: Error) => e.message);
+    const err2 = await adapter.generateEmbedding("b").catch((e: Error) => e.message);
+    expect(err1).toEqual(err2);
+  });
+});
+```
+
+- [ ] **Step 2: Run the missing-dep test (RED)**
+
+```bash
+cd /Users/geraldonyango/Documents/dev/prism-mcp && npx vitest run tests/llm/local-missing-dep.test.ts 2>&1 | tail -20
+```
+
+Expected: These tests pass immediately since the adapter is already implemented. If they fail, check that the `ERR_MODULE_NOT_FOUND` handling in `initPipeline` is correct (see Task 3, Step 3).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/llm/local-missing-dep.test.ts
+git commit -m "test: ERR_MODULE_NOT_FOUND path via separate mock-throw test file"
+```
+
+---
+
+## Task 6: Factory wiring — tests and implementation
+
+**Files:**
+- Modify: `tests/llm/factory.test.ts`
+- Modify: `src/utils/llm/factory.ts`
+
+This task has one important behavioral change: the existing test "falls back to Gemini+Gemini when text adapter throws on init" tested the old behavior (always fall back to Gemini). The new design surfaces errors when providers are explicitly configured. That test must be updated.
+
+- [ ] **Step 1: Update imports and mocks in `tests/llm/factory.test.ts`**
+
+Open `tests/llm/factory.test.ts`. Add mocks for the two new adapters alongside the existing ones (after the existing `vi.mock` for VoyageAdapter):
+
+```typescript
+vi.mock("../../src/utils/llm/adapters/local.js", () => ({
+  LocalEmbeddingAdapter: vi.fn(function (this: any) {
+    this.generateEmbedding = vi.fn();
+    this.generateText = vi.fn().mockRejectedValue(
+      new Error("LocalEmbeddingAdapter does not support text generation")
+    );
+    this.loadPromise = Promise.resolve();
+  }),
+}));
+
+vi.mock("../../src/utils/llm/adapters/disabledText.js", () => ({
+  DisabledTextAdapter: vi.fn(function (this: any) {
+    this.generateText = vi.fn().mockRejectedValue(
+      new Error("Text generation is not available")
+    );
+    this.generateEmbedding = vi.fn().mockRejectedValue(
+      new Error("DisabledTextAdapter.generateEmbedding should not be called")
+    );
+  }),
+}));
+```
+
+Add the new imports at the top of the file (after existing imports):
+
+```typescript
+import { LocalEmbeddingAdapter } from "../../src/utils/llm/adapters/local.js";
+import { DisabledTextAdapter } from "../../src/utils/llm/adapters/disabledText.js";
+const mockLocalAdapter    = vi.mocked(LocalEmbeddingAdapter);
+const mockDisabledAdapter = vi.mocked(DisabledTextAdapter);
+```
+
+- [ ] **Step 2: Update the existing "falls back to Gemini" test**
+
+Find this test (around line 215 in `tests/llm/factory.test.ts`):
+
+```typescript
+it("falls back to Gemini+Gemini when text adapter throws on init", () => {
+  mockProviders("openai", "auto", { openai_api_key: "" }); // missing key
+  vi.mocked(OpenAIAdapter).mockImplementationOnce(() => {
+    throw new Error("Missing API key");
+  });
+
+  const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const provider = getLLMProvider();
+  expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Falling back to GeminiAdapter for both"));
+  expect(GeminiAdapter).toHaveBeenCalledOnce();
+  expect(provider).toBeDefined();
+  consoleSpy.mockRestore();
+});
+```
+
+Replace it with TWO tests — one for the explicit case (now throws) and one for the default case (now gracefully falls back):
+
+```typescript
+it("throws when EXPLICIT text_provider=openai fails (explicit choice honored)", () => {
+  mockProviders("openai", "auto", { openai_api_key: "" });
+  vi.mocked(OpenAIAdapter).mockImplementationOnce(() => {
+    throw new Error("Missing API key");
+  });
+
+  // explicit text_provider=openai → should throw, NOT silently fall back
+  expect(() => getLLMProvider()).toThrow("Missing API key");
+  expect(GeminiAdapter).not.toHaveBeenCalled();
+  expect(mockLocalAdapter).not.toHaveBeenCalled();
+});
+
+it("falls back to DisabledTextAdapter when DEFAULT text provider (gemini) fails", () => {
+  // text_provider defaults to "gemini" (not explicitly set)
+  mockProviders("gemini", "auto");
+  vi.mocked(GeminiAdapter).mockImplementationOnce(() => {
+    throw new Error("GOOGLE_API_KEY not set");
+  });
+
+  const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  const provider = getLLMProvider();
+  expect(mockDisabledAdapter).toHaveBeenCalledOnce();
+  // Gemini was tried for text (failed) AND still used for embedding (auto→gemini)
+  // so GeminiAdapter is called once for embed (second attempt)
+  expect(provider).toBeDefined();
+  expect(typeof provider.generateText).toBe("function");
+  warnSpy.mockRestore();
+});
+```
+
+- [ ] **Step 3: Add the 5 new factory test cases**
+
+Append these inside the main `describe` block in `tests/llm/factory.test.ts`:
+
+```typescript
+  // ── Local embedding provider ───────────────────────────────────────────────
+
+  it("embedding_provider=local → uses LocalEmbeddingAdapter", () => {
+    mockProviders("gemini", "local");
+    getLLMProvider();
+    expect(mockLocalAdapter).toHaveBeenCalledOnce();
+    expect(GeminiAdapter).toHaveBeenCalledOnce(); // text only
+    expect(VoyageAdapter).not.toHaveBeenCalled();
+    expect(OpenAIAdapter).not.toHaveBeenCalled();
+  });
+
+  it("auto-fallback to LocalEmbeddingAdapter when embedding_provider=auto resolve fails", () => {
+    // embedding_provider=auto resolves to "gemini"; GeminiAdapter (embed) throws
+    mockProviders("anthropic", "auto", { anthropic_api_key: "sk-ant-test" });
+    // First GeminiAdapter call (for embed) throws; text (AnthropicAdapter) succeeds
+    vi.mocked(GeminiAdapter)
+      .mockImplementationOnce(function (this: any) {
+        // The text uses Anthropic, embed tries Gemini — make the embed call throw
+        throw new Error("GOOGLE_API_KEY not set");
+      });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const provider = getLLMProvider();
+    expect(mockLocalAdapter).toHaveBeenCalledOnce();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("re-index"));
+    expect(provider).toBeDefined();
+    warnSpy.mockRestore();
+    infoSpy.mockRestore();
+  });
+
+  it("auto-fallback log mentions embedding model change risk", () => {
+    mockProviders("gemini", "auto");
+    vi.mocked(GeminiAdapter).mockImplementationOnce(() => {
+      throw new Error("GOOGLE_API_KEY not set");
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    getLLMProvider();
+    const calls = warnSpy.mock.calls.map(([msg]) => msg as string);
+    const hasReindexWarning = calls.some((msg) => msg?.includes("re-index"));
+    expect(hasReindexWarning).toBe(true);
+    warnSpy.mockRestore();
+  });
+
+  it("DisabledTextAdapter.generateText() throws concise message without env var names", async () => {
+    mockProviders("gemini", "auto");
+    vi.mocked(GeminiAdapter).mockImplementationOnce(() => {
+      throw new Error("GOOGLE_API_KEY not set");
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const provider = getLLMProvider();
+    try {
+      await provider.generateText("hello");
+    } catch (e) {
+      const msg = (e as Error).message;
+      expect(msg).toContain("not available");
+      expect(msg).not.toContain("GOOGLE_API_KEY");
+      expect(msg).not.toContain("OPENAI_API_KEY");
+      expect(msg).not.toContain("ANTHROPIC_API_KEY");
+    }
+    warnSpy.mockRestore();
+  });
+
+  it("explicit embedding_provider=voyage + voyage fails → throws (not overridden)", () => {
+    mockProviders("gemini", "voyage", { voyage_api_key: "" });
+    vi.mocked(VoyageAdapter).mockImplementationOnce(() => {
+      throw new Error("Voyage AI API key not set");
+    });
+    expect(() => getLLMProvider()).toThrow("Voyage AI API key not set");
+    expect(mockLocalAdapter).not.toHaveBeenCalled();
+  });
+```
+
+- [ ] **Step 4: Run factory tests (RED — should fail until factory is updated)**
+
+```bash
+cd /Users/geraldonyango/Documents/dev/prism-mcp && npx vitest run tests/llm/factory.test.ts 2>&1 | tail -40
+```
+
+Expected: New tests fail. The "throws when EXPLICIT text_provider=openai fails" test will fail because the current factory still falls back to Gemini instead of throwing.
+
+- [ ] **Step 5: Update factory.ts imports**
+
+Open `src/utils/llm/factory.ts`. Add imports for the new adapters after the VoyageAdapter import:
+
+```typescript
+import { LocalEmbeddingAdapter } from "./adapters/local.js";
+import { DisabledTextAdapter } from "./adapters/disabledText.js";
+```
+
+- [ ] **Step 6: Update `buildEmbeddingAdapter` in factory.ts**
+
+Find the existing `buildEmbeddingAdapter` function and add the `"local"` case:
+
+```typescript
+function buildEmbeddingAdapter(type: string): LLMProvider {
+  switch (type) {
+    case "openai": return new OpenAIAdapter();
+    case "voyage": return new VoyageAdapter();
+    case "local":  return new LocalEmbeddingAdapter();
+    case "gemini":
+    default:       return new GeminiAdapter();
+  }
+}
+```
+
+- [ ] **Step 7: Refactor `getLLMProvider` in factory.ts**
+
+Replace the entire `getLLMProvider` function body (keeping the JSDoc comment above it) with:
+
+```typescript
+export function getLLMProvider(): LLMProvider {
+  if (providerInstance) return providerInstance;
+
+  const textType            = getSettingSync("text_provider", "gemini");
+  const originalEmbedSetting = getSettingSync("embedding_provider", "auto");
+  let embedType             = originalEmbedSetting;
+
+  if (embedType === "auto") {
+    embedType = textType === "anthropic" ? "gemini" : textType;
+    if (textType === "anthropic") {
+      console.info(
+        "[LLMFactory] text_provider=anthropic with embedding_provider=auto: " +
+        "routing embeddings to GeminiAdapter (Anthropic has no native embedding API). " +
+        "For the Anthropic-recommended pairing, set embedding_provider=voyage in the dashboard " +
+        "(voyage-3 supports 768-dim output via MRL). " +
+        "Alternatively, set embedding_provider=openai to use Ollama/OpenAI."
+      );
+    }
+  }
+
+  // ── Build text adapter ─────────────────────────────────────────────────────
+  // Explicit text_provider choice (anything other than the default "gemini") is
+  // honored: failures surface as errors rather than silent fallback.
+  let textAdapter: LLMProvider;
+  try {
+    textAdapter = buildTextAdapter(textType);
+  } catch (textErr) {
+    if (textType !== "gemini") {
+      // User explicitly configured a text provider — surface the error.
+      throw textErr;
+    }
+    // Default Gemini text provider failed (no API key configured) → degrade.
+    console.warn(
+      `[LLMFactory] Default text provider (gemini) failed to init: ` +
+      `${textErr instanceof Error ? textErr.message : String(textErr)}. ` +
+      `Text generation will be unavailable. Set GOOGLE_API_KEY or configure ` +
+      `a text provider in the dashboard.`
+    );
+    textAdapter = new DisabledTextAdapter();
+  }
+
+  // ── Build embedding adapter ────────────────────────────────────────────────
+  // Explicit embedding_provider choice is honored: failures surface as errors.
+  // embedding_provider=auto failures degrade to LocalEmbeddingAdapter.
+  let embedAdapter: LLMProvider;
+  try {
+    embedAdapter = buildEmbeddingAdapter(embedType);
+  } catch (embedErr) {
+    if (originalEmbedSetting !== "auto") {
+      // User explicitly set embedding_provider — honor that choice.
+      throw embedErr;
+    }
+    // Auto-resolved embedding provider failed → fall back to local.
+    console.warn(
+      `[LLMFactory] embedding_provider=auto resolved to "${embedType}" but failed: ` +
+      `${embedErr instanceof Error ? embedErr.message : String(embedErr)}. ` +
+      `Falling back to LocalEmbeddingAdapter. ` +
+      `⚠️  Embedding model has changed. Existing vectors may be incompatible — ` +
+      `re-index all entries to restore search quality.`
+    );
+    embedAdapter = new LocalEmbeddingAdapter();
+  }
+
+  // ── Compose and wrap ───────────────────────────────────────────────────────
+  const composed: LLMProvider = {
+    generateText:      textAdapter.generateText.bind(textAdapter),
+    generateEmbedding: embedAdapter.generateEmbedding.bind(embedAdapter),
+  };
+  if (textAdapter.generateImageDescription) {
+    composed.generateImageDescription = textAdapter.generateImageDescription.bind(textAdapter);
+  }
+
+  if (textType !== embedType) {
+    console.info(`[LLMFactory] Split provider: text=${textType}, embedding=${embedType}`);
+  }
+
+  providerInstance = new TracingLLMProvider(composed, textType);
+  return providerInstance;
+}
+```
+
+- [ ] **Step 8: Run all factory tests (GREEN)**
+
+```bash
+cd /Users/geraldonyango/Documents/dev/prism-mcp && npx vitest run tests/llm/factory.test.ts 2>&1 | tail -50
+```
+
+Expected: all tests pass. Watch for:
+- "Singleton" test: should still work (GeminiAdapter × 2 on first call, same instance on second)
+- "Gemini+Gemini default" test: GeminiAdapter called twice (text + embed)
+- The new "explicit text throws" test: verify factory throws, not falls back
+- The new "local" routing test: LocalEmbeddingAdapter constructed
+
+If the "Singleton" test says `GeminiAdapter called 4 times` instead of 2: check that the singleton path (`if (providerInstance) return providerInstance`) is reached on the second call.
+
+- [ ] **Step 9: Commit factory changes**
+
+```bash
+git add src/utils/llm/factory.ts tests/llm/factory.test.ts src/utils/llm/adapters/local.ts
+git commit -m "feat(GREEN): factory wiring — local case, split try/catch, explicit-choice-preserving fallback"
+```
+
+---
+
+## Task 7: Full test suite + TypeScript build
+
+**Files:** none — verification only
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+cd /Users/geraldonyango/Documents/dev/prism-mcp && npm test 2>&1 | tail -50
+```
+
+Expected: all tests pass with zero failures. If existing tests fail, check:
+- The "Gemini+Gemini singleton" test — `GeminiAdapter` called count may have changed
+- The "anthropic auto-bridge" test — still works (logic is preserved in new getLLMProvider)
+- The "split provider" tests — still work
+
+- [ ] **Step 2: TypeScript build**
+
+```bash
+cd /Users/geraldonyango/Documents/dev/prism-mcp && npm run build 2>&1 | head -30
+```
+
+Expected: zero errors. Common errors to fix:
+- `FeatureExtractionPipeline` type not found → already handled with callable type in `local.ts`
+- `dtype` not in pipeline options type → add `as any` or type assertion on the options object if needed: `{ dtype, revision } as Record<string, unknown>`
+- `loadPromise` not accessible in test → already declared as `readonly`
+
+- [ ] **Step 3: Fix any build errors then re-run tests**
+
+If `npm run build` reports type errors for the pipeline options (transformers.js v3 types may not include `dtype` in the options type definition), update the pipeline call in `local.ts`:
+
+```typescript
+const pipelineInstance = await (transformers as any).pipeline(
+  "feature-extraction",
+  model,
+  { dtype, revision },
+);
+```
+
+Or cast only the options:
+```typescript
+const pipelineInstance = await transformers.pipeline(
+  "feature-extraction",
+  model,
+  { dtype, revision } as Parameters<typeof transformers.pipeline>[2],
+);
+```
+
+Re-run tests after any fix to confirm nothing broke.
+
+- [ ] **Step 4: Commit if any fixes were needed**
+
+```bash
+git add -A
+git commit -m "fix: resolve tsc type errors for transformers.js pipeline options"
+```
+
+---
+
+## Task 8: Simplify and clean up
+
+- [ ] **Step 1: Review changed files for duplication and clarity**
+
+Check these specific things:
+
+1. `src/utils/llm/adapters/local.ts`: does the `initPipeline` error handling have any redundancy? Is `this.pipe` ever accessed after `loadError` is set? (It shouldn't be — the guard `if (this.loadError) throw` fires first.)
+
+2. `src/utils/llm/factory.ts`: are the two warn messages (text fallback and embedding fallback) distinct enough that an operator can tell them apart in logs? They should both include `[LLMFactory]` and different context.
+
+3. `tests/llm/local.test.ts`: the `beforeEach` clears `process.env.LOCAL_EMBEDDING_MODEL` and `process.env.HF_ENDPOINT`. Verify this prevents test pollution.
+
+- [ ] **Step 2: Commit any simplifications**
+
+```bash
+git add -A
+git commit -m "refactor: simplify local adapter and factory after review"
+```
+
+---
+
+## Task 9: Final commit
+
+- [ ] **Step 1: Run full test suite one more time**
+
+```bash
+cd /Users/geraldonyango/Documents/dev/prism-mcp && npm test 2>&1 | tail -20
+```
+
+Expected: all tests pass, zero failures.
+
+- [ ] **Step 2: Run build one more time**
+
+```bash
+cd /Users/geraldonyango/Documents/dev/prism-mcp && npm run build 2>&1 | tail -10
+```
+
+Expected: zero errors.
+
+- [ ] **Step 3: Verify git log shows feature branch with clean commits**
+
+```bash
+git log --oneline feat/local-embeddings-transformers-js 2>&1 | head -15
+```
+
+- [ ] **Step 4: Final summary commit if needed**
+
+If there are any uncommitted changes:
+
+```bash
+git add -A
+git commit -m "feat: local embedding provider via transformers.js + nomic-embed-text-v1.5
+
+Adds LocalEmbeddingAdapter using @huggingface/transformers (optional peer dep)
+to generate 768-dim embeddings fully locally. Factory falls back to Local when
+embedding_provider=auto and all configured API keys are absent. Explicit provider
+choices throw on failure rather than silently degrading.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+
+| Spec requirement | Task |
+|---|---|
+| `LocalEmbeddingAdapter` implements `LLMProvider` | Task 3 |
+| `DisabledTextAdapter` stub | Task 2 |
+| Model ID validation (rejects paths/URLs) | Task 3 |
+| `dtype: "q8"` (not `quantized:boolean`) | Task 3 |
+| `Array.from(result.data)` Tensor extraction | Task 3 |
+| Warmup non-fatal | Task 3 |
+| Background init (non-blocking constructor) | Task 3 |
+| Factory "local" case in `buildEmbeddingAdapter` | Task 6 |
+| Separate text/embed try/catch in factory | Task 6 |
+| Explicit choices throw; auto paths degrade | Task 6 |
+| `@huggingface/transformers` optional peer dep | Task 1 |
+| `~3.1.0` semver + exact devDep | Task 1 |
+| `DEFAULT_REVISION` pin | Task 3 |
+| `HF_ENDPOINT` warning | Task 3 |
+| 13 adapter unit tests | Task 4 |
+| ERR_MODULE_NOT_FOUND test | Task 5 |
+| 5 new factory tests (14–18) | Task 6 |
+| Updated "explicit throws" factory test | Task 6 |
+| `npm test` passes | Task 7 |
+| `npm run build` passes | Task 7 |
+
+All spec requirements have a corresponding task. No gaps.

--- a/docs/superpowers/specs/2026-04-14-local-embeddings-transformers-js-design.md
+++ b/docs/superpowers/specs/2026-04-14-local-embeddings-transformers-js-design.md
@@ -24,7 +24,7 @@ We want a **fully local embedding path** so Prism can:
 **Goals**
 
 1. Add a `LocalEmbeddingAdapter` that satisfies the existing `LLMProvider` interface for the embedding half (text generation explicitly unsupported, mirroring `VoyageAdapter`).
-2. Use [`@huggingface/transformers`](https://www.npmjs.com/package/@huggingface/transformers) to run [`Xenova/nomic-embed-text-v1.5`](https://huggingface.co/Xenova/nomic-embed-text-v1.5) (q8 quantized ONNX) locally via onnxruntime-node.
+2. Use [`@huggingface/transformers`](https://www.npmjs.com/package/@huggingface/transformers) to run [`nomic-ai/nomic-embed-text-v1.5`](https://huggingface.co/nomic-ai/nomic-embed-text-v1.5) (q8 quantized ONNX) locally via onnxruntime-node.
 3. Output exactly **768-dim** vectors so existing storage schemas, TurboQuant compression, and SDM cognitive engine work unchanged.
 4. Activate via two paths:
    - Explicit: `embedding_provider=local`
@@ -178,7 +178,7 @@ private async initPipeline(): Promise<void> {
   // Pin to a specific model revision to prevent silent updates if the HuggingFace
   // repository is updated or compromised (CWE-494).
   // IMPORTANT: When updating DEFAULT_MODEL or DEFAULT_REVISION, verify the new
-  // revision SHA from https://huggingface.co/Xenova/nomic-embed-text-v1.5/commits/main
+  // revision SHA from https://huggingface.co/nomic-ai/nomic-embed-text-v1.5/commits/main
   const revision = getSettingSync("local_embedding_revision", DEFAULT_REVISION);
 
   try {
@@ -352,7 +352,7 @@ export class DisabledTextAdapter implements LLMProvider {
 | Setting key | Default | Read via | Purpose |
 |---|---|---|---|
 | `embedding_provider` | `"auto"` | `getSettingSync` | New accepted value: `"local"` |
-| `local_embedding_model` | `"Xenova/nomic-embed-text-v1.5"` | `getSettingSync`, then `process.env.LOCAL_EMBEDDING_MODEL` | HuggingFace model ID (format: `owner/name` only) |
+| `local_embedding_model` | `"nomic-ai/nomic-embed-text-v1.5"` | `getSettingSync`, then `process.env.LOCAL_EMBEDDING_MODEL` | HuggingFace model ID (format: `owner/name` only) |
 | `local_embedding_quantized` | `"true"` | `getSettingSync` | Maps to `dtype: "q8"` (true) or `dtype: "fp32"` (false) |
 | `local_embedding_revision` | pinned SHA | `getSettingSync` | HuggingFace model revision commit SHA |
 
@@ -459,7 +459,7 @@ These are explicitly out of scope for this PR:
 - [ ] Factory auto-falls-back to Local only when `embedding_provider=auto` fails; explicit choices throw.
 - [ ] Factory auto-falls-back to Disabled text only when `text_provider` is default/unset; explicit text choices throw.
 - [ ] `package.json` has `@huggingface/transformers ~3.1.0` as optional peer dep + exact version devDep.
-- [ ] `DEFAULT_REVISION` constant is set to the pinned commit SHA for `Xenova/nomic-embed-text-v1.5`.
+- [ ] `DEFAULT_REVISION` constant is set to the pinned commit SHA for `nomic-ai/nomic-embed-text-v1.5`.
 - [ ] Warmup failure is non-fatal (logs warn, does NOT set `loadError`).
 - [ ] `dtype: "q8"` (not `quantized: boolean`) is used in the pipeline options.
 - [ ] Tensor extraction uses `Array.from(result.data)` (`Float32Array` access, not nested array).

--- a/docs/superpowers/specs/2026-04-14-local-embeddings-transformers-js-design.md
+++ b/docs/superpowers/specs/2026-04-14-local-embeddings-transformers-js-design.md
@@ -1,7 +1,7 @@
 # Local Embeddings via transformers.js — Design Spec
 
 **Date:** 2026-04-14
-**Status:** Draft → in implementation
+**Status:** Plan review complete → ready for implementation
 **Author:** Gerald Onyango (via Claude)
 **Scope:** `prism-mcp` fork (`futuregerald/prism-mcp`)
 
@@ -41,6 +41,7 @@ We want a **fully local embedding path** so Prism can:
 - GPU acceleration. CPU-only via WASM/onnxruntime-node. Performance is sufficient for Prism's bursty write workload.
 - Multiple concurrent local model variants. One model loaded per process.
 - Distinguishing query vs. document embeddings (nomic supports `search_query: ` vs `search_document: ` prefixes). The `LLMProvider` interface has a single method; we use `search_document: ` for everything. Recall hit on query-side is ~1-2% per nomic's own benchmarks. Documented as a follow-up if it becomes load-bearing.
+- Architecture-enforced network isolation. The "no external requests" property is a guarantee of the default model, not the code. Model ID validation (§3.4) is the enforcement boundary — a user-supplied model could include ONNX operators that make outbound calls. Users requiring strict air-gap enforcement should apply OS-level network namespace restrictions.
 
 ---
 
@@ -57,8 +58,8 @@ tests/llm/local.test.ts                  # Adapter unit tests
 ### 3.2 Modified files
 
 ```
-src/utils/llm/factory.ts                 # New "local" case + auto-fallback path
-package.json                             # Add @huggingface/transformers as optional peer dep
+src/utils/llm/factory.ts                 # New "local" case + separate text/embed fallback paths
+package.json                             # @huggingface/transformers optional peer dep + devDep
 tests/llm/factory.test.ts                # New routing + fallback tests
 ```
 
@@ -66,33 +67,47 @@ tests/llm/factory.test.ts                # New routing + fallback tests
 
 ```ts
 class LocalEmbeddingAdapter implements LLMProvider {
-  private loadPromise: Promise<void> | null = null;
-  private pipeline: FeatureExtractionPipeline | null = null;
+  private loadPromise: Promise<void>;
+  // Typed as a callable to avoid importing FeatureExtractionPipeline directly
+  // (dynamic import means the type is not available at compile time when the
+  // peer dep is absent). Full type: Awaited<ReturnType<typeof pipeline>>.
+  private pipe: ((text: string, opts: object) => Promise<unknown>) | null = null;
   private loadError: Error | null = null;
 
   constructor() {
-    // Read settings, kick off background load. Returns immediately.
+    // Kick off background load. Returns immediately; server boot is not blocked.
     this.loadPromise = this.initPipeline();
   }
 
-  async generateText(): Promise<string> {
+  async generateText(_prompt: string, _systemInstruction?: string): Promise<string> {
+    // Embedding-only — same pattern as VoyageAdapter.
+    // Client-facing message intentionally omits env var names (CWE-209).
     throw new Error(
       "LocalEmbeddingAdapter does not support text generation. " +
       "It is an embedding-only provider. " +
-      "Set text_provider to 'gemini', 'openai', or 'anthropic' in the dashboard."
+      "Configure a text provider in the Mind Palace dashboard."
     );
   }
 
   async generateEmbedding(text: string): Promise<number[]> {
-    // 1. Empty/whitespace guard
+    // 1. Empty/whitespace guard — same contract as all other adapters
+    if (!text || !text.trim()) {
+      throw new Error("[LocalEmbeddingAdapter] generateEmbedding called with empty text");
+    }
     // 2. Truncate to MAX_EMBEDDING_CHARS (8000) with word-boundary snap
-    // 3. await loadPromise; throw loadError if set
-    // 4. Run pipeline with "search_document: " prefix, mean pooling, L2 normalize
-    // 5. Convert Tensor → number[]
-    // 6. Hard 768-dim guard → throw on mismatch
+    //    (consistent with GeminiAdapter, OpenAIAdapter, VoyageAdapter)
+    // 3. await this.loadPromise — waits for the background init to settle
+    // 4. if (this.loadError) throw this.loadError — surfaces init failures
+    // 5. Run this.pipe(`search_document: ${truncated}`, { pooling: "mean", normalize: true })
+    // 6. Extract float vector: const vec = Array.from((result as any).data as Float32Array)
+    //    NOTE: transformers.js returns Tensor { data: Float32Array, dims: [1, 768] }.
+    //    Access .data directly — do NOT use .tolist(), [...result], or Array.from(result).
+    //    Array.from(result.data) yields the flat 768-element float array.
+    // 7. Hard 768-dim guard — throw on length mismatch
+    //    (protects against user switching local_embedding_model to a 384-dim model)
   }
 
-  // No generateImageDescription
+  // No generateImageDescription (embedding-only)
 }
 ```
 
@@ -100,40 +115,113 @@ class LocalEmbeddingAdapter implements LLMProvider {
 
 ```ts
 private async initPipeline(): Promise<void> {
+  // ── Step 1: Validate model ID before any outbound activity ────────────────
+  const model = getSettingSync("local_embedding_model", DEFAULT_MODEL);
+  const env = process.env.LOCAL_EMBEDDING_MODEL;
+  const resolvedModel = env ?? model;
+
+  // Enforce HuggingFace model ID format: "owner/name"
+  // Rejects: absolute paths, relative paths (../), file:// URIs, full URLs.
+  // A malicious or misconfigured model ID can trigger SSRF or load arbitrary
+  // ONNX weights (CWE-918, CWE-73). Validate before touching the network.
+  const MODEL_ID_PATTERN = /^[a-zA-Z0-9_-]{1,64}\/[a-zA-Z0-9._-]{1,128}$/;
+  if (!MODEL_ID_PATTERN.test(resolvedModel) || resolvedModel.includes("..")) {
+    this.loadError = new Error(
+      `[LocalEmbeddingAdapter] Invalid local_embedding_model: "${resolvedModel}". ` +
+      `Must be a HuggingFace model ID in the format "owner/name" ` +
+      `(e.g., "${DEFAULT_MODEL}"). Paths and URLs are not permitted.`
+    );
+    return;
+  }
+
+  // ── Step 2: Warn if HF_ENDPOINT is set to a non-official domain ──────────
+  // HF_ENDPOINT redirects ALL model downloads to the specified server.
+  // If set to an attacker-controlled host, it bypasses HuggingFace's CDN
+  // integrity guarantees and can deliver malicious ONNX weights (CWE-494).
+  const hfEndpoint = process.env.HF_ENDPOINT;
+  if (hfEndpoint && !hfEndpoint.includes("huggingface.co")) {
+    console.warn(
+      `[LocalEmbeddingAdapter] HF_ENDPOINT is set to "${hfEndpoint}" — ` +
+      `model downloads are redirected to this host. ` +
+      `Only set HF_ENDPOINT if you control and trust this server. ` +
+      `Unset it to use the official HuggingFace CDN.`
+    );
+  }
+
+  // ── Step 3: Dynamic import (optional peer dep) ────────────────────────────
+  // transformers.js is not in dependencies; users who want local embeddings
+  // install it separately. If absent, we store the error and let
+  // generateEmbedding() surface a clear install instruction.
   let transformers: typeof import("@huggingface/transformers");
   try {
     transformers = await import("@huggingface/transformers");
   } catch (err) {
-    if ((err as NodeJS.ErrnoException)?.code === "ERR_MODULE_NOT_FOUND") {
+    const e = err instanceof Error ? err : new Error(String(err));
+    if ((e as NodeJS.ErrnoException).code === "ERR_MODULE_NOT_FOUND") {
       this.loadError = new Error(
-        "Local embeddings require @huggingface/transformers. " +
+        "[LocalEmbeddingAdapter] @huggingface/transformers is not installed. " +
         "Run: npm install @huggingface/transformers"
       );
-      return;
+    } else {
+      this.loadError = e;
     }
-    this.loadError = err as Error;
     return;
   }
 
+  // ── Step 4: Load the pipeline ─────────────────────────────────────────────
+  // dtype: "q8" is the correct v3 API. The old `quantized: boolean` option was
+  // removed in @huggingface/transformers v3.x. Using `quantized` would be
+  // silently ignored, causing the full ~550 MB fp32 model to load.
+  const quantized = getSettingSync("local_embedding_quantized", "true") !== "false";
+  const dtype = quantized ? "q8" : "fp32";
+
+  // Pin to a specific model revision to prevent silent updates if the HuggingFace
+  // repository is updated or compromised (CWE-494).
+  // IMPORTANT: When updating DEFAULT_MODEL or DEFAULT_REVISION, verify the new
+  // revision SHA from https://huggingface.co/Xenova/nomic-embed-text-v1.5/commits/main
+  const revision = getSettingSync("local_embedding_revision", DEFAULT_REVISION);
+
   try {
-    const model = getSettingSync("local_embedding_model", DEFAULT_MODEL);
-    const quantized = getSettingSync("local_embedding_quantized", "true") !== "false";
-    this.pipeline = await transformers.pipeline("feature-extraction", model, {
-      quantized,
-      // dtype: quantized ? "q8" : "fp32",  // newer API; fall back to {quantized} if unavailable
-    });
-    // Warmup forces ONNX session init so the first real call isn't slow
-    await this.pipeline("warmup", { pooling: "mean", normalize: true });
-    debugLog(`[LocalEmbeddingAdapter] Pipeline ready: ${model}`);
+    const pipelineInstance = await transformers.pipeline(
+      "feature-extraction",
+      resolvedModel,
+      { dtype, revision },
+    );
+    this.pipe = pipelineInstance as (text: string, opts: object) => Promise<unknown>;
+
+    // Warmup forces ONNX session initialization so the first real call is fast.
+    // Warmup failure is NOT fatal — it means a slightly slower first call.
+    // It MUST NOT set this.loadError (which would permanently disable the adapter).
+    try {
+      await this.pipe("warmup text", { pooling: "mean", normalize: true });
+      debugLog(`[LocalEmbeddingAdapter] Pipeline ready and warmed up: ${resolvedModel} (${dtype})`);
+    } catch (warmupErr) {
+      const we = warmupErr instanceof Error ? warmupErr : new Error(String(warmupErr));
+      console.warn(
+        `[LocalEmbeddingAdapter] Warmup failed (non-fatal): ${we.message}. ` +
+        `First embedding call may be slightly slower.`
+      );
+      debugLog(`[LocalEmbeddingAdapter] Pipeline ready (no warmup): ${resolvedModel} (${dtype})`);
+    }
   } catch (err) {
-    this.loadError = err as Error;
+    this.loadError = err instanceof Error ? err : new Error(String(err));
+    console.error(
+      `[LocalEmbeddingAdapter] Failed to load pipeline: ${this.loadError.message}`
+    );
   }
 }
 ```
 
+**Key corrections from plan review:**
+- `dtype: "q8"` not `{ quantized: boolean }` (v3 API, not v2)
+- Model ID validated before any network activity (SSRF/path traversal guard)
+- `DEFAULT_REVISION` pins the commit SHA (integrity guard)
+- Warmup has its own try/catch — failure warns but does NOT disable the adapter
+- All `catch (err)` blocks normalize to `Error` via `instanceof` check
+
 ### 3.5 Factory wiring
 
-`buildEmbeddingAdapter()` gains a `"local"` case:
+`buildEmbeddingAdapter()` gains a `"local"` case (unchanged from earlier draft):
 
 ```ts
 function buildEmbeddingAdapter(type: string): LLMProvider {
@@ -147,43 +235,90 @@ function buildEmbeddingAdapter(type: string): LLMProvider {
 }
 ```
 
-The `getLLMProvider()` resolution adds an auto-fallback path. **Critically, the fallback only triggers when the user did not explicitly choose providers** — i.e. when the *original* `embedding_provider` setting was `"auto"`. If a user explicitly set `embedding_provider=voyage` and Voyage construction throws, we surface the error rather than silently overriding their choice.
-
-The factory must preserve the *original* setting (before `"auto"` was resolved to a concrete provider name) to know whether the auto-fallback path is allowed. Implementation captures it in a local `originalEmbedSetting` variable.
+`getLLMProvider()` uses **separate try/catch blocks** for the text and embedding adapters, preserving original settings to honor explicit user choices:
 
 ```ts
-const textType = getSettingSync("text_provider", "gemini");
+const originalTextSetting  = getSettingSync("text_provider", "gemini");
 const originalEmbedSetting = getSettingSync("embedding_provider", "auto");
 let embedType = originalEmbedSetting;
+let textType  = originalTextSetting;
 
 if (embedType === "auto") {
-  // ...existing anthropic→gemini auto-bridge logic...
+  // Existing anthropic→gemini auto-bridge logic (unchanged)
+  embedType = textType === "anthropic" ? "gemini" : textType;
+  if (textType === "anthropic") { /* existing info log */ }
 }
 
+// ── Build text adapter (may fail if API key missing) ──────────────────────
+let textAdapter: LLMProvider;
 try {
-  const textAdapter  = buildTextAdapter(textType);
-  const embedAdapter = buildEmbeddingAdapter(embedType);
-  // ...existing happy-path composition...
-} catch (err) {
-  // Only auto-fall-back to local when the user did NOT explicitly choose
-  // an embedding provider. Explicit choices are honored: the error bubbles.
-  if (originalEmbedSetting !== "auto") {
-    throw err;
+  textAdapter = buildTextAdapter(textType);
+} catch (textErr) {
+  if (originalTextSetting !== "gemini" && originalEmbedSetting !== "auto") {
+    // User explicitly chose both providers — bubble the error.
+    throw textErr;
   }
-  console.error(
-    `[LLMFactory] Failed to initialise providers (text=${textType}, embed=${embedType}): ${err}. ` +
-    `embedding_provider was 'auto' → falling back to LocalEmbeddingAdapter for embeddings ` +
-    `and DisabledTextAdapter for text.`
+  // text_provider was default ("gemini") or embedding was "auto":
+  // degrade to DisabledTextAdapter. Log with warn (expected path, not an error).
+  console.warn(
+    `[LLMFactory] text_provider=${textType} failed to init: ${textErr}. ` +
+    `Falling back to DisabledTextAdapter for text generation.`
   );
-  const embed = new LocalEmbeddingAdapter();
-  const text  = new DisabledTextAdapter();
-  // ...compose & return as before, wrapped in TracingLLMProvider...
+  textAdapter = new DisabledTextAdapter();
 }
+
+// ── Build embedding adapter (may fail if API key missing) ─────────────────
+let embedAdapter: LLMProvider;
+try {
+  embedAdapter = buildEmbeddingAdapter(embedType);
+} catch (embedErr) {
+  if (originalEmbedSetting !== "auto") {
+    // User explicitly chose an embedding provider — honor that choice, bubble.
+    throw embedErr;
+  }
+  // embedding_provider was "auto" — fall back to local embeddings.
+  console.warn(
+    `[LLMFactory] embedding_provider=auto resolved to ${embedType} but failed: ${embedErr}. ` +
+    `Falling back to LocalEmbeddingAdapter. ` +
+    `⚠️  Embedding model has changed. Existing vectors may be incompatible — ` +
+    `re-index all entries to restore search quality.`
+  );
+  embedAdapter = new LocalEmbeddingAdapter();
+}
+
+// ── Compose & wrap (existing happy-path logic) ────────────────────────────
+const composed: LLMProvider = {
+  generateText:      textAdapter.generateText.bind(textAdapter),
+  generateEmbedding: embedAdapter.generateEmbedding.bind(embedAdapter),
+};
+if (textAdapter.generateImageDescription) {
+  composed.generateImageDescription = textAdapter.generateImageDescription.bind(textAdapter);
+}
+providerInstance = new TracingLLMProvider(composed, textType);
 ```
 
-**Why this matters:** the previous draft said "fall through to local on any error" but the code example matched a different (looser) policy. The tightened version keeps explicit user intent intact and is testable: a test with `embedding_provider=voyage` + missing voyage key must throw, not silently degrade.
+**Why separate try/catch blocks matter:**
+- Explicit `text_provider=openai` + missing key: text adapter throws → surfaced as error (not silently replaced with Disabled)
+- Explicit `embedding_provider=voyage` + missing key: embedding adapter throws → surfaced as error (not silently replaced with Local)
+- Both on `"auto"` / default + missing keys: both degrade gracefully — this is the "truly keyless" path
 
-`DisabledTextAdapter` is a 20-line stub whose `generateText()` throws `"No text provider is configured. Set GOOGLE_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY, or configure a provider in the Mind Palace dashboard."` Its `generateEmbedding()` also throws (it should never be called — the factory routes embeddings through Local).
+`DisabledTextAdapter` (`src/utils/llm/adapters/disabledText.ts`):
+```ts
+export class DisabledTextAdapter implements LLMProvider {
+  async generateText(_prompt: string, _systemInstruction?: string): Promise<string> {
+    // Client-facing message is intentionally brief (CWE-209 — env var enumeration).
+    // Actionable guidance lives in the server-side console.warn above.
+    throw new Error(
+      "Text generation is not available. " +
+      "Configure an AI provider in the Mind Palace dashboard."
+    );
+  }
+  async generateEmbedding(_text: string): Promise<number[]> {
+    // Should never be called — factory routes embeddings to LocalEmbeddingAdapter.
+    throw new Error("[DisabledTextAdapter] generateEmbedding should not be called directly.");
+  }
+}
+```
 
 ### 3.6 Dependency wiring
 
@@ -193,27 +328,39 @@ try {
 {
   "peerDependencies": {
     "typescript": "^5.0.0",
-    "@huggingface/transformers": "^3.0.0"
+    "@huggingface/transformers": "~3.1.0"
   },
   "peerDependenciesMeta": {
     "@huggingface/transformers": { "optional": true }
+  },
+  "devDependencies": {
+    "@huggingface/transformers": "3.1.0"
   }
 }
 ```
 
-Users who never set `embedding_provider=local` are unaffected. Users who do see a clear error pointing them to the install command.
+**Version pinning rationale (IMPORTANT from review):**
+- `^3.0.0` (any 3.x) was rejected: onnxruntime-node C++ native changes in a minor release could silently change model loading behavior, or a compromised `3.x` release could introduce RCE via the ONNX loading path.
+- `~3.1.0` (patch-level updates only) limits exposure to security patches within the tested minor.
+- The `devDependency` at an exact version ensures the package-lock.json is authoritative for CI. Users get `~3.1.0` compatibility; CI tests against exactly `3.1.0`.
+- When upgrading: update both `peerDependencies` and `devDependencies`, verify in CI, update `DEFAULT_REVISION` if the default model changes.
 
 ---
 
 ## 4. Configuration Surface
 
-| Setting key | Env var | Default | Purpose |
+| Setting key | Default | Read via | Purpose |
 |---|---|---|---|
-| `embedding_provider` | — | `"auto"` | New accepted value: `"local"` |
-| `local_embedding_model` | `LOCAL_EMBEDDING_MODEL` | `"Xenova/nomic-embed-text-v1.5"` | HuggingFace model ID |
-| `local_embedding_quantized` | `LOCAL_EMBEDDING_QUANTIZED` | `true` | q8 vs fp32 |
+| `embedding_provider` | `"auto"` | `getSettingSync` | New accepted value: `"local"` |
+| `local_embedding_model` | `"Xenova/nomic-embed-text-v1.5"` | `getSettingSync`, then `process.env.LOCAL_EMBEDDING_MODEL` | HuggingFace model ID (format: `owner/name` only) |
+| `local_embedding_quantized` | `"true"` | `getSettingSync` | Maps to `dtype: "q8"` (true) or `dtype: "fp32"` (false) |
+| `local_embedding_revision` | pinned SHA | `getSettingSync` | HuggingFace model revision commit SHA |
 
-Model cache lives in the default transformers.js cache: `~/.cache/huggingface/hub/`. Users can override via `HF_HOME` env var if they need a different location (handled by transformers.js, not us).
+**Note on env var support:** `getSettingSync` reads from the Prism config SQLite store. The `local_embedding_model` key is the exception — it also checks `process.env.LOCAL_EMBEDDING_MODEL` directly to support Docker/container deployments where config DB is not convenient. Other `local_*` keys read only from the config store; no env var fallback.
+
+**Model cache:** `~/.cache/huggingface/hub/` (transformers.js default). Override via `HF_ENDPOINT` (see §3.4 warning) or `HF_HOME`. Cache directory should be owned and writable only by the MCP server process user.
+
+**`HF_ENDPOINT` risk:** If set to a non-HuggingFace host in the server's environment, all model downloads are redirected. The `LocalEmbeddingAdapter` warns at startup if this is detected. Never set `HF_ENDPOINT` unless you control and trust the target server.
 
 ---
 
@@ -221,13 +368,16 @@ Model cache lives in the default transformers.js cache: `~/.cache/huggingface/hu
 
 | Failure | Server state | Behavior on `generateEmbedding()` |
 |---|---|---|
-| `@huggingface/transformers` not installed | Up | Throws: `"Local embeddings require @huggingface/transformers. Run: npm install @huggingface/transformers"` |
-| Model download fails (network, disk full, HF outage) | Up | Throws underlying error with hint |
-| Model loaded but inference throws | Up | Bubbles the error, next call retries (transient ONNX failures recover) |
-| Wrong dimension returned (e.g., user swapped model to a 384-dim one) | Up | Throws dimension mismatch error pointing to `local_embedding_model` setting |
-| Auto-fallback path: no API keys at all | Up | Local adapter handles embeddings; `DisabledTextAdapter` throws on `generateText` |
+| `@huggingface/transformers` not installed | Up | Throws: `"@huggingface/transformers is not installed. Run: npm install @huggingface/transformers"` |
+| Invalid `local_embedding_model` format (path, URL) | Up | Throws validation error at init; `generateEmbedding()` throws on every call |
+| Model download fails (network, disk full, HF outage) | Up | Throws underlying error |
+| Warmup fails | Up | **Non-fatal** — adapter continues; first real call pays ~200ms ONNX init cost |
+| Model loaded but inference throws | Up | Bubbles the error; next call retries (transient ONNX failures recover) |
+| Wrong dimension returned (user switched to a 384-dim model) | Up | Throws: `"dimension mismatch: expected 768, got N. Check local_embedding_model setting."` |
+| Auto-fallback path: no API keys at all | Up | Local adapter handles embeddings; `DisabledTextAdapter` throws on `generateText` with concise message |
+| **Embedding model changed mid-lifecycle** | Up | ⚠️ Silent quality degradation — vectors from different models coexist in the DB. Factory logs a prominent `console.warn`. Re-index all entries to restore search quality (no automated migration). |
 
-The server **never** crashes due to local adapter failures. The worst case is "embeddings are unavailable but everything else works," which matches Prism's existing behavior under transient cloud failures.
+**Mixed-vector risk:** If the `embedding_provider` auto-fallback fires and the previous provider was different (e.g., Gemini → Local), embeddings from different model families coexist in the vector store. Cosine similarity between them is meaningless. The factory warns loudly when this happens. A follow-up task should add an `embedding_model` metadata column to vector entries for detection and targeted re-indexing.
 
 ---
 
@@ -235,49 +385,53 @@ The server **never** crashes due to local adapter failures. The worst case is "e
 
 ### 6.1 Unit tests — `tests/llm/local.test.ts`
 
-`@huggingface/transformers` is fully mocked via `vi.mock`. The mock exposes a fake `pipeline()` that returns a callable returning an object shaped like `{ data: Float32Array, dims: [1, 768] }`.
+`@huggingface/transformers` is fully mocked via `vi.mock`. The mock exposes a fake `pipeline()` factory that returns a callable. That callable returns an object shaped like `{ data: new Float32Array(768).fill(0.1), dims: [1, 768] }` (simulating the Tensor shape).
 
 Test cases:
 
-1. **Construction is synchronous** — `new LocalEmbeddingAdapter()` doesn't await anything; the constructor returns immediately even if the mocked pipeline factory hangs.
-2. **`generateText()` throws** with an actionable message containing "embedding-only".
-3. **Happy path** — `generateEmbedding("hello world")` returns `number[]` of length 768 after the background load resolves.
-4. **search_document prefix is applied** — the mocked pipeline receives the input text *with* `"search_document: "` prepended.
+1. **Construction is synchronous** — `new LocalEmbeddingAdapter()` returns immediately even if `initPipeline()` hangs.
+2. **`generateText()` throws** with a message containing "embedding-only" (does NOT leak env var names).
+3. **Happy path** — `await adapter.loadPromise` first to let background init settle, then `generateEmbedding("hello world")` returns `number[]` of length 768. Explicitly awaiting `loadPromise` before calling `generateEmbedding` is acceptable since `generateEmbedding` also awaits it internally — the test should verify the round-trip, not just the final array length.
+4. **search_document prefix is applied** — mock pipeline callable's `calls[0][0]` equals `"search_document: hello world"`.
 5. **Empty input throws** — `""` and `"   \n  "` both throw.
-6. **Long text is truncated word-safely** to `MAX_EMBEDDING_CHARS = 8000`.
-7. **Dimension guard** — mock returns 384-dim vector → throws with "expected 768".
-8. **Module not found** — mock throws `ERR_MODULE_NOT_FOUND` on import → first embedding call throws the friendly install message; subsequent calls also throw (cached load error).
-9. **Pipeline init failure** — mock throws on `pipeline()` call → first embedding call throws the underlying error.
-10. **Pooling + normalize options are passed** to the pipeline call.
+6. **Long text is truncated word-safely** to `MAX_EMBEDDING_CHARS = 8000` — verify the mock receives ≤8000 chars.
+7. **Dimension guard** — mock callable returns 384-element array → `generateEmbedding` throws with "expected 768".
+8. **Module not found** — mock the dynamic import to throw with `code: "ERR_MODULE_NOT_FOUND"` → first embedding call throws with "not installed" message; `loadError` is cached, subsequent calls throw the same error.
+9. **Pipeline init failure** — mock `pipeline()` factory to throw → first embedding call throws; warmup failure does NOT block this (test verifies init error propagation, not warmup).
+10. **Pooling + normalize options are passed** — mock callable records call args; verify `{ pooling: "mean", normalize: true }` is in the options.
+11. **Warmup failure is non-fatal** — mock warmup call to throw, but `pipeline()` itself succeeds → `generateEmbedding` still works (no `loadError` set).
+12. **Model ID validation** — supply `"../evil/path"` or `"https://bad.com/model"` as `local_embedding_model` → `generateEmbedding` throws with "Invalid local_embedding_model".
+13. **`Array.from(result.data)` extraction** — mock returns `{ data: Float32Array([...768 floats...]), dims: [1, 768] }` with known values; verify returned array equals `Array.from(data)` exactly (not a nested array, not `Array.from(result)`).
 
 ### 6.2 Factory tests — extend `tests/llm/factory.test.ts`
 
 New cases:
 
-11. **`embedding_provider=local`** → builds `LocalEmbeddingAdapter`, no other embedding adapters constructed.
-12. **Auto-fallback to Local** — text adapter construction throws AND `embedding_provider=auto` → factory builds `LocalEmbeddingAdapter` and `DisabledTextAdapter`.
-13. **Auto-fallback log message** mentions both Local and Disabled.
-14. **`DisabledTextAdapter.generateText()`** throws an actionable error.
-15. **Explicit embedding_provider is preserved on failure** — `text_provider=anthropic`, `embedding_provider=voyage`, voyage throws → factory throws (no silent override). This guards the explicit-choice contract.
-16. **Existing tests still pass** unchanged.
+14. **`embedding_provider=local`** → builds `LocalEmbeddingAdapter`, no other embedding adapters constructed.
+15. **Auto-fallback: embedding adapter throws + `embedding_provider=auto`** → factory builds `LocalEmbeddingAdapter`; logs a `console.warn` containing "re-index".
+16. **Auto-fallback: text adapter throws + default `text_provider`** → factory builds `DisabledTextAdapter` for text; `DisabledTextAdapter.generateText()` throws a concise message (no env var names).
+17. **Explicit `embedding_provider=voyage` + voyage throws** → factory throws (explicit choice not silently overridden).
+18. **Explicit `text_provider=openai` + OpenAI throws** → factory throws (explicit text choice not silently overridden).
+19. **Existing tests still pass** unchanged (all prior routing and singleton tests).
 
 ### 6.3 No real model loads
 
-Unit tests must not download or run the real ONNX model. Keeps CI under 60 seconds and avoids flakiness. An optional `tests/llm/local.integration.test.ts` gated on `process.env.RUN_INTEGRATION === "1"` can be added later for a real end-to-end check.
+Unit tests must not download or run the real ONNX model. CI stays fast. An optional `tests/llm/local.integration.test.ts` gated on `process.env.RUN_INTEGRATION === "1"` can be added later for a real end-to-end check.
 
 ---
 
 ## 7. Migration & Rollout
 
-- **Existing users unaffected.** Default `embedding_provider=auto` continues to route to gemini/openai/anthropic+gemini exactly as today as long as keys are present.
-- **No DB migration.** Vector dimension is unchanged.
+- **Existing users unaffected.** Default `embedding_provider=auto` with API keys configured continues routing exactly as before.
+- **No DB migration.** Vector dimension is unchanged (768).
 - **No lockfile bloat for non-users.** `@huggingface/transformers` is a peer dep, not a regular dep.
 - **Opt-in flow:**
-  1. `npm install @huggingface/transformers`
-  2. Set `embedding_provider=local` in the dashboard or `embedding_provider=local` in env/config
+  1. `npm install @huggingface/transformers@3.1.x`
+  2. Set `embedding_provider=local` in the dashboard
   3. Restart MCP server
-  4. First request triggers background download; first embedding call may briefly wait for it
-- **Implicit fallback flow:** Users with no API keys configured will silently get local embeddings (after `npm install @huggingface/transformers`). Without the peer dep installed, they see the friendly error message.
+  4. First request triggers background download; first embedding call awaits it
+- **Implicit fallback flow:** Users with no API keys configured will silently get local embeddings (after peer dep install). Without the peer dep, they see the friendly install error.
+- **⚠️ Mixed-vector risk on first fallback:** If a deployment was previously using Gemini/OpenAI/Voyage embeddings and the adapter switches to Local (via auto-fallback after key deletion), existing vectors and new vectors are from different model families. Re-indexing all entries is required to restore semantic search quality. The factory warns prominently when this transition occurs.
 
 ---
 
@@ -287,21 +441,30 @@ These are explicitly out of scope for this PR:
 
 1. **Dashboard UI** for picking the local provider, model, and quantization. Follow-up PR.
 2. **Query vs. document prefix distinction.** Would require interface change to `generateEmbedding(text, kind?)`. Defer until it's measured to matter.
-3. **Multiple model variants** (e.g., a code-specialized model for code-heavy sessions). Defer.
-4. **Worker thread isolation** of ONNX inference. onnxruntime-node releases the libuv thread pool, so the event loop stays responsive on a multi-core machine. Worker thread is unnecessary for v1.
-5. **Integration test** with a real model load. Worth adding as a `RUN_INTEGRATION=1`-gated test once the adapter has shipped and stabilized.
+3. **Multiple model variants** (e.g., a code-specialized model). Defer.
+4. **Worker thread isolation** of ONNX inference. `onnxruntime-node` releases the libuv thread pool; event loop stays responsive on multi-core. Worker thread unnecessary for v1.
+5. **Integration test** with real model load, gated on `RUN_INTEGRATION=1`. Defer to post-ship.
+6. **`embedding_model` metadata column** in vector entries for mixed-model detection and targeted re-indexing. Follow-up.
+7. **Re-indexing tooling** for when the embedding model changes (e.g., a `prism reindex` CLI command). Follow-up.
 
 ---
 
 ## 9. Acceptance Criteria
 
 - [ ] `LocalEmbeddingAdapter` exists and implements `LLMProvider`.
-- [ ] `DisabledTextAdapter` exists and throws actionable errors on text calls.
+- [ ] `DisabledTextAdapter` exists and throws concise errors (no env var enumeration) on text calls.
+- [ ] Model ID is validated before `transformers.pipeline()` is called (rejects paths, URLs).
+- [ ] Factory uses **separate try/catch** for text and embedding adapter construction.
 - [ ] Factory routes `embedding_provider=local` to `LocalEmbeddingAdapter`.
-- [ ] Factory falls back to Local + Disabled when text adapter construction throws and `embedding_provider=auto`.
-- [ ] `package.json` has `@huggingface/transformers` as an optional peer dependency.
-- [ ] Unit tests in `tests/llm/local.test.ts` cover all 10 adapter test cases.
-- [ ] Factory tests in `tests/llm/factory.test.ts` cover the 4 new cases.
+- [ ] Factory auto-falls-back to Local only when `embedding_provider=auto` fails; explicit choices throw.
+- [ ] Factory auto-falls-back to Disabled text only when `text_provider` is default/unset; explicit text choices throw.
+- [ ] `package.json` has `@huggingface/transformers ~3.1.0` as optional peer dep + exact version devDep.
+- [ ] `DEFAULT_REVISION` constant is set to the pinned commit SHA for `Xenova/nomic-embed-text-v1.5`.
+- [ ] Warmup failure is non-fatal (logs warn, does NOT set `loadError`).
+- [ ] `dtype: "q8"` (not `quantized: boolean`) is used in the pipeline options.
+- [ ] Tensor extraction uses `Array.from(result.data)` (`Float32Array` access, not nested array).
+- [ ] Unit tests cover all 13 adapter test cases (§6.1).
+- [ ] Factory tests cover all 5 new routing cases (§6.2, tests 14–18).
 - [ ] All existing tests still pass.
 - [ ] `npm run build` (tsc) passes with zero errors.
 - [ ] No 768-dim assumption is broken anywhere in the stack.

--- a/docs/superpowers/specs/2026-04-14-local-embeddings-transformers-js-design.md
+++ b/docs/superpowers/specs/2026-04-14-local-embeddings-transformers-js-design.md
@@ -1,0 +1,307 @@
+# Local Embeddings via transformers.js — Design Spec
+
+**Date:** 2026-04-14
+**Status:** Draft → in implementation
+**Author:** Gerald Onyango (via Claude)
+**Scope:** `prism-mcp` fork (`futuregerald/prism-mcp`)
+
+---
+
+## 1. Problem
+
+Prism currently generates embeddings for semantic memory search via four cloud / API-driven adapters (`gemini`, `openai`, `anthropic` (auto-bridged), `voyage`). Every embedding write costs an outbound HTTPS call, an API quota slot, and (for keyless self-hosters) a hard dependency on third-party services being reachable.
+
+We want a **fully local embedding path** so Prism can:
+
+- Run with zero API keys configured (truly offline / air-gapped friendly).
+- Avoid leaking session memory text to third parties for users who want it.
+- Let the existing `auto` resolution silently degrade to local instead of crashing when no API keys exist.
+
+---
+
+## 2. Goals & Non-Goals
+
+**Goals**
+
+1. Add a `LocalEmbeddingAdapter` that satisfies the existing `LLMProvider` interface for the embedding half (text generation explicitly unsupported, mirroring `VoyageAdapter`).
+2. Use [`@huggingface/transformers`](https://www.npmjs.com/package/@huggingface/transformers) to run [`Xenova/nomic-embed-text-v1.5`](https://huggingface.co/Xenova/nomic-embed-text-v1.5) (q8 quantized ONNX) locally via onnxruntime-node.
+3. Output exactly **768-dim** vectors so existing storage schemas, TurboQuant compression, and SDM cognitive engine work unchanged.
+4. Activate via two paths:
+   - Explicit: `embedding_provider=local`
+   - Implicit: `embedding_provider=auto` AND text adapter construction fails (no API keys) → fall through to Local for embeddings + a `DisabledTextAdapter` for text.
+5. Ship transformers.js as an **optional peer dependency** so users who don't want it pay zero install cost.
+6. Background-load the model at server startup; never block server boot.
+7. Server stays up even if local model can't be loaded — embedding calls throw with actionable errors.
+
+**Non-Goals**
+
+- Local text generation (no Phi/Llama/Mistral). This adapter is embedding-only.
+- Schema migrations or making embedding dimension configurable. We commit to 768 dims permanently.
+- Dashboard UI changes for the new provider. Deferred to a follow-up PR.
+- GPU acceleration. CPU-only via WASM/onnxruntime-node. Performance is sufficient for Prism's bursty write workload.
+- Multiple concurrent local model variants. One model loaded per process.
+- Distinguishing query vs. document embeddings (nomic supports `search_query: ` vs `search_document: ` prefixes). The `LLMProvider` interface has a single method; we use `search_document: ` for everything. Recall hit on query-side is ~1-2% per nomic's own benchmarks. Documented as a follow-up if it becomes load-bearing.
+
+---
+
+## 3. Architecture
+
+### 3.1 New files
+
+```
+src/utils/llm/adapters/local.ts          # LocalEmbeddingAdapter
+src/utils/llm/adapters/disabledText.ts   # DisabledTextAdapter (text-side stub)
+tests/llm/local.test.ts                  # Adapter unit tests
+```
+
+### 3.2 Modified files
+
+```
+src/utils/llm/factory.ts                 # New "local" case + auto-fallback path
+package.json                             # Add @huggingface/transformers as optional peer dep
+tests/llm/factory.test.ts                # New routing + fallback tests
+```
+
+### 3.3 LocalEmbeddingAdapter contract
+
+```ts
+class LocalEmbeddingAdapter implements LLMProvider {
+  private loadPromise: Promise<void> | null = null;
+  private pipeline: FeatureExtractionPipeline | null = null;
+  private loadError: Error | null = null;
+
+  constructor() {
+    // Read settings, kick off background load. Returns immediately.
+    this.loadPromise = this.initPipeline();
+  }
+
+  async generateText(): Promise<string> {
+    throw new Error(
+      "LocalEmbeddingAdapter does not support text generation. " +
+      "It is an embedding-only provider. " +
+      "Set text_provider to 'gemini', 'openai', or 'anthropic' in the dashboard."
+    );
+  }
+
+  async generateEmbedding(text: string): Promise<number[]> {
+    // 1. Empty/whitespace guard
+    // 2. Truncate to MAX_EMBEDDING_CHARS (8000) with word-boundary snap
+    // 3. await loadPromise; throw loadError if set
+    // 4. Run pipeline with "search_document: " prefix, mean pooling, L2 normalize
+    // 5. Convert Tensor → number[]
+    // 6. Hard 768-dim guard → throw on mismatch
+  }
+
+  // No generateImageDescription
+}
+```
+
+### 3.4 Background pipeline init
+
+```ts
+private async initPipeline(): Promise<void> {
+  let transformers: typeof import("@huggingface/transformers");
+  try {
+    transformers = await import("@huggingface/transformers");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ERR_MODULE_NOT_FOUND") {
+      this.loadError = new Error(
+        "Local embeddings require @huggingface/transformers. " +
+        "Run: npm install @huggingface/transformers"
+      );
+      return;
+    }
+    this.loadError = err as Error;
+    return;
+  }
+
+  try {
+    const model = getSettingSync("local_embedding_model", DEFAULT_MODEL);
+    const quantized = getSettingSync("local_embedding_quantized", "true") !== "false";
+    this.pipeline = await transformers.pipeline("feature-extraction", model, {
+      quantized,
+      // dtype: quantized ? "q8" : "fp32",  // newer API; fall back to {quantized} if unavailable
+    });
+    // Warmup forces ONNX session init so the first real call isn't slow
+    await this.pipeline("warmup", { pooling: "mean", normalize: true });
+    debugLog(`[LocalEmbeddingAdapter] Pipeline ready: ${model}`);
+  } catch (err) {
+    this.loadError = err as Error;
+  }
+}
+```
+
+### 3.5 Factory wiring
+
+`buildEmbeddingAdapter()` gains a `"local"` case:
+
+```ts
+function buildEmbeddingAdapter(type: string): LLMProvider {
+  switch (type) {
+    case "openai": return new OpenAIAdapter();
+    case "voyage": return new VoyageAdapter();
+    case "local":  return new LocalEmbeddingAdapter();
+    case "gemini":
+    default:       return new GeminiAdapter();
+  }
+}
+```
+
+The `getLLMProvider()` resolution adds an auto-fallback path. **Critically, the fallback only triggers when the user did not explicitly choose providers** — i.e. when the *original* `embedding_provider` setting was `"auto"`. If a user explicitly set `embedding_provider=voyage` and Voyage construction throws, we surface the error rather than silently overriding their choice.
+
+The factory must preserve the *original* setting (before `"auto"` was resolved to a concrete provider name) to know whether the auto-fallback path is allowed. Implementation captures it in a local `originalEmbedSetting` variable.
+
+```ts
+const textType = getSettingSync("text_provider", "gemini");
+const originalEmbedSetting = getSettingSync("embedding_provider", "auto");
+let embedType = originalEmbedSetting;
+
+if (embedType === "auto") {
+  // ...existing anthropic→gemini auto-bridge logic...
+}
+
+try {
+  const textAdapter  = buildTextAdapter(textType);
+  const embedAdapter = buildEmbeddingAdapter(embedType);
+  // ...existing happy-path composition...
+} catch (err) {
+  // Only auto-fall-back to local when the user did NOT explicitly choose
+  // an embedding provider. Explicit choices are honored: the error bubbles.
+  if (originalEmbedSetting !== "auto") {
+    throw err;
+  }
+  console.error(
+    `[LLMFactory] Failed to initialise providers (text=${textType}, embed=${embedType}): ${err}. ` +
+    `embedding_provider was 'auto' → falling back to LocalEmbeddingAdapter for embeddings ` +
+    `and DisabledTextAdapter for text.`
+  );
+  const embed = new LocalEmbeddingAdapter();
+  const text  = new DisabledTextAdapter();
+  // ...compose & return as before, wrapped in TracingLLMProvider...
+}
+```
+
+**Why this matters:** the previous draft said "fall through to local on any error" but the code example matched a different (looser) policy. The tightened version keeps explicit user intent intact and is testable: a test with `embedding_provider=voyage` + missing voyage key must throw, not silently degrade.
+
+`DisabledTextAdapter` is a 20-line stub whose `generateText()` throws `"No text provider is configured. Set GOOGLE_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY, or configure a provider in the Mind Palace dashboard."` Its `generateEmbedding()` also throws (it should never be called — the factory routes embeddings through Local).
+
+### 3.6 Dependency wiring
+
+`package.json`:
+
+```json
+{
+  "peerDependencies": {
+    "typescript": "^5.0.0",
+    "@huggingface/transformers": "^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@huggingface/transformers": { "optional": true }
+  }
+}
+```
+
+Users who never set `embedding_provider=local` are unaffected. Users who do see a clear error pointing them to the install command.
+
+---
+
+## 4. Configuration Surface
+
+| Setting key | Env var | Default | Purpose |
+|---|---|---|---|
+| `embedding_provider` | — | `"auto"` | New accepted value: `"local"` |
+| `local_embedding_model` | `LOCAL_EMBEDDING_MODEL` | `"Xenova/nomic-embed-text-v1.5"` | HuggingFace model ID |
+| `local_embedding_quantized` | `LOCAL_EMBEDDING_QUANTIZED` | `true` | q8 vs fp32 |
+
+Model cache lives in the default transformers.js cache: `~/.cache/huggingface/hub/`. Users can override via `HF_HOME` env var if they need a different location (handled by transformers.js, not us).
+
+---
+
+## 5. Failure Modes
+
+| Failure | Server state | Behavior on `generateEmbedding()` |
+|---|---|---|
+| `@huggingface/transformers` not installed | Up | Throws: `"Local embeddings require @huggingface/transformers. Run: npm install @huggingface/transformers"` |
+| Model download fails (network, disk full, HF outage) | Up | Throws underlying error with hint |
+| Model loaded but inference throws | Up | Bubbles the error, next call retries (transient ONNX failures recover) |
+| Wrong dimension returned (e.g., user swapped model to a 384-dim one) | Up | Throws dimension mismatch error pointing to `local_embedding_model` setting |
+| Auto-fallback path: no API keys at all | Up | Local adapter handles embeddings; `DisabledTextAdapter` throws on `generateText` |
+
+The server **never** crashes due to local adapter failures. The worst case is "embeddings are unavailable but everything else works," which matches Prism's existing behavior under transient cloud failures.
+
+---
+
+## 6. Testing Strategy
+
+### 6.1 Unit tests — `tests/llm/local.test.ts`
+
+`@huggingface/transformers` is fully mocked via `vi.mock`. The mock exposes a fake `pipeline()` that returns a callable returning an object shaped like `{ data: Float32Array, dims: [1, 768] }`.
+
+Test cases:
+
+1. **Construction is synchronous** — `new LocalEmbeddingAdapter()` doesn't await anything; the constructor returns immediately even if the mocked pipeline factory hangs.
+2. **`generateText()` throws** with an actionable message containing "embedding-only".
+3. **Happy path** — `generateEmbedding("hello world")` returns `number[]` of length 768 after the background load resolves.
+4. **search_document prefix is applied** — the mocked pipeline receives the input text *with* `"search_document: "` prepended.
+5. **Empty input throws** — `""` and `"   \n  "` both throw.
+6. **Long text is truncated word-safely** to `MAX_EMBEDDING_CHARS = 8000`.
+7. **Dimension guard** — mock returns 384-dim vector → throws with "expected 768".
+8. **Module not found** — mock throws `ERR_MODULE_NOT_FOUND` on import → first embedding call throws the friendly install message; subsequent calls also throw (cached load error).
+9. **Pipeline init failure** — mock throws on `pipeline()` call → first embedding call throws the underlying error.
+10. **Pooling + normalize options are passed** to the pipeline call.
+
+### 6.2 Factory tests — extend `tests/llm/factory.test.ts`
+
+New cases:
+
+11. **`embedding_provider=local`** → builds `LocalEmbeddingAdapter`, no other embedding adapters constructed.
+12. **Auto-fallback to Local** — text adapter construction throws AND `embedding_provider=auto` → factory builds `LocalEmbeddingAdapter` and `DisabledTextAdapter`.
+13. **Auto-fallback log message** mentions both Local and Disabled.
+14. **`DisabledTextAdapter.generateText()`** throws an actionable error.
+15. **Explicit embedding_provider is preserved on failure** — `text_provider=anthropic`, `embedding_provider=voyage`, voyage throws → factory throws (no silent override). This guards the explicit-choice contract.
+16. **Existing tests still pass** unchanged.
+
+### 6.3 No real model loads
+
+Unit tests must not download or run the real ONNX model. Keeps CI under 60 seconds and avoids flakiness. An optional `tests/llm/local.integration.test.ts` gated on `process.env.RUN_INTEGRATION === "1"` can be added later for a real end-to-end check.
+
+---
+
+## 7. Migration & Rollout
+
+- **Existing users unaffected.** Default `embedding_provider=auto` continues to route to gemini/openai/anthropic+gemini exactly as today as long as keys are present.
+- **No DB migration.** Vector dimension is unchanged.
+- **No lockfile bloat for non-users.** `@huggingface/transformers` is a peer dep, not a regular dep.
+- **Opt-in flow:**
+  1. `npm install @huggingface/transformers`
+  2. Set `embedding_provider=local` in the dashboard or `embedding_provider=local` in env/config
+  3. Restart MCP server
+  4. First request triggers background download; first embedding call may briefly wait for it
+- **Implicit fallback flow:** Users with no API keys configured will silently get local embeddings (after `npm install @huggingface/transformers`). Without the peer dep installed, they see the friendly error message.
+
+---
+
+## 8. Open Questions / Follow-ups
+
+These are explicitly out of scope for this PR:
+
+1. **Dashboard UI** for picking the local provider, model, and quantization. Follow-up PR.
+2. **Query vs. document prefix distinction.** Would require interface change to `generateEmbedding(text, kind?)`. Defer until it's measured to matter.
+3. **Multiple model variants** (e.g., a code-specialized model for code-heavy sessions). Defer.
+4. **Worker thread isolation** of ONNX inference. onnxruntime-node releases the libuv thread pool, so the event loop stays responsive on a multi-core machine. Worker thread is unnecessary for v1.
+5. **Integration test** with a real model load. Worth adding as a `RUN_INTEGRATION=1`-gated test once the adapter has shipped and stabilized.
+
+---
+
+## 9. Acceptance Criteria
+
+- [ ] `LocalEmbeddingAdapter` exists and implements `LLMProvider`.
+- [ ] `DisabledTextAdapter` exists and throws actionable errors on text calls.
+- [ ] Factory routes `embedding_provider=local` to `LocalEmbeddingAdapter`.
+- [ ] Factory falls back to Local + Disabled when text adapter construction throws and `embedding_provider=auto`.
+- [ ] `package.json` has `@huggingface/transformers` as an optional peer dependency.
+- [ ] Unit tests in `tests/llm/local.test.ts` cover all 10 adapter test cases.
+- [ ] Factory tests in `tests/llm/factory.test.ts` cover the 4 new cases.
+- [ ] All existing tests still pass.
+- [ ] `npm run build` (tsc) passes with zero errors.
+- [ ] No 768-dim assumption is broken anywhere in the stack.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prism-mcp-server",
-  "version": "9.4.5",
+  "version": "9.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prism-mcp-server",
-      "version": "9.4.5",
+      "version": "9.4.6",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.81.0",
@@ -39,6 +39,7 @@
         "prism-mcp-server": "dist/server.js"
       },
       "devDependencies": {
+        "@huggingface/transformers": "3.1.0",
         "@types/bun": "latest",
         "@types/jsdom": "^28.0.1",
         "@types/mozilla-readability": "^0.2.1",
@@ -48,7 +49,13 @@
         "vitest": "^4.1.1"
       },
       "peerDependencies": {
+        "@huggingface/transformers": "~3.1.0",
         "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@huggingface/transformers": {
+          "optional": true
+        }
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -214,7 +221,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -261,9 +267,31 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -757,6 +785,422 @@
         "hono": "^4"
       }
     },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.3.4.tgz",
+      "integrity": "sha512-kFFQWJiWwvxezKQnvH1X7GjsECcMljFx+UZK9hx6P26aVHwwidJVTB0ptLfRVZQvVkOGHoMmTGvo4nT0X9hHOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.1.0.tgz",
+      "integrity": "sha512-NeaZk/KBBrvy8v8gvRBE5bficnn1a9cKJDJlgr9jv+fcEiqsgqt5Mh7LKKuLxeO/bFtLppFceJVwM9gbUQyLnA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.3.2",
+        "onnxruntime-node": "1.20.1",
+        "onnxruntime-web": "1.20.1",
+        "sharp": "^0.33.5"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@jitl/quickjs-ffi-types": {
       "version": "0.32.0",
       "resolved": "https://registry.npmjs.org/@jitl/quickjs-ffi-types/-/quickjs-ffi-types-0.32.0.tgz",
@@ -1052,7 +1496,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2161,6 +2604,61 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -2710,7 +3208,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2856,6 +3353,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/flatbuffers": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
+      "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -3030,6 +3534,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -3074,7 +3585,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
       "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3199,6 +3709,13 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
@@ -3729,6 +4246,29 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3866,6 +4406,45 @@
         "wrappy": "1"
       }
     },
+    "node_modules/onnxruntime-common": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.20.1.tgz",
+      "integrity": "sha512-YiU0s0IzYYC+gWvqD1HzLc46Du1sXpSiwzKb63PACIJr6LfL27VsXSXQvt68EzD3V0D5Bc0vyJTjmMxp0ylQiw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.20.1.tgz",
+      "integrity": "sha512-di/I4HDXRw+FLgq+TyHmQEDd3cEp9iFFZm0r4uJ1Wd7b/WE1VXtKWo8yemex347c6GNF/3Pv86ZfPhIWxORr0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "onnxruntime-common": "1.20.1",
+        "tar": "^7.0.1"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.20.1.tgz",
+      "integrity": "sha512-TePF6XVpLL1rWVMIl5Y9ACBQcyCNFThZON/jgElNd9Txb73CIEGlklhYR3UEr1cp5r0rbGI6nDwwrs79g7WjoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^1.12.0",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.20.1",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
     "node_modules/openai": {
       "version": "6.33.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.33.0.tgz",
@@ -3999,7 +4578,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4015,6 +4593,13 @@
       "engines": {
         "node": ">=16.20.0"
       }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/postcss": {
       "version": "8.5.8",
@@ -4273,6 +4858,19 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
@@ -4323,6 +4921,56 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/sharp/node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4424,6 +5072,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4482,6 +5140,23 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "license": "MIT"
+    },
+    "node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -4596,7 +5271,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -4692,7 +5366,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4987,6 +5660,16 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "license": "MIT"
     },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
@@ -5004,7 +5687,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
   "author": "Dmitri Costenco",
   "license": "MIT",
   "devDependencies": {
+    "@huggingface/transformers": "3.1.0",
     "@types/bun": "latest",
     "@types/jsdom": "^28.0.1",
     "@types/mozilla-readability": "^0.2.1",
@@ -99,7 +100,13 @@
     "vitest": "^4.1.1"
   },
   "peerDependencies": {
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "@huggingface/transformers": "~3.1.0"
+  },
+  "peerDependenciesMeta": {
+    "@huggingface/transformers": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.81.0",

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -101,10 +101,10 @@ export async function startDashboardServer(): Promise<void> {
   const AUTH_USER = process.env.PRISM_DASHBOARD_USER || "";
   const AUTH_PASS = process.env.PRISM_DASHBOARD_PASS || "";
   const AUTH_JWKS_URI = process.env.PRISM_JWKS_URI || process.env.AUTH_JWKS_URI || "";
-  
+
   // Auth is enabled if basic auth is configured OR if JWKS is configured
   const AUTH_ENABLED = (AUTH_USER.length > 0 && AUTH_PASS.length > 0) || AUTH_JWKS_URI.length > 0;
-  
+
   if (AUTH_JWKS_URI) {
     initJWKS(AUTH_JWKS_URI);
   }
@@ -409,7 +409,7 @@ return false;}
           console.error("[Dashboard] SSE Connection failed:", err);
           activeSSETransports.delete(transport.sessionId);
         }
-        
+
         return; // SSEServerTransport handles keeping the response open
       }
 
@@ -522,7 +522,7 @@ return false;}
               let cursorId: string | undefined = undefined;
               let iterations = 0;
               const MAX_ITERATIONS = 100; // safety cap: 100 × 50 = 5000 entries max
-              
+
               while (hasMore && iterations < MAX_ITERATIONS) {
                 iterations++;
                 const result: any = await backfillEmbeddingsHandler({ dry_run: false, limit: 50, _cursor_id: cursorId });
@@ -560,8 +560,8 @@ return false;}
           }
           if (cleaned.length > 0) cleanupMessages.push(`Cleaned ${cleaned.length} orphaned handoffs`);
 
-          const message = cleanupMessages.length > 0 
-            ? cleanupMessages.join(", ") 
+          const message = cleanupMessages.length > 0
+            ? cleanupMessages.join(", ")
             : "No issues to clean up.";
 
           res.writeHead(200, { "Content-Type": "application/json" });
@@ -960,12 +960,12 @@ return false;}
       if (url.pathname === "/api/scholar/trigger" && req.method === "POST") {
         try {
           const { runWebScholar } = await import("../scholar/webScholar.js");
-          
+
           // Fire and forget, don't block the request
           runWebScholar().catch(err => {
             console.error("[Dashboard] Web Scholar async trigger failed:", err);
           });
-          
+
           res.writeHead(200, { "Content-Type": "application/json" });
           return res.end(JSON.stringify({ ok: true, message: "Autonomous research started in background" }));
         } catch (err: any) {
@@ -1008,12 +1008,12 @@ return false;}
             llm = getLLMProvider();
           } catch {
             res.writeHead(503, { "Content-Type": "application/json" });
-            return res.end(JSON.stringify({ error: "LLM Provider not configured for semantic search. Provide a GOOGLE_API_KEY or equivalent." }));
+            return res.end(JSON.stringify({ error: "LLM Provider not configured for semantic search. Configure an embedding provider in the Mind Palace dashboard." }));
           }
 
           const queryEmbedding = await llm.generateEmbedding(queryText);
 
-          // We query limit + offset, then slice manually since the storage 
+          // We query limit + offset, then slice manually since the storage
           // layer interface limit parameter doesn't natively expose offset.
           const results = await s!.searchMemory({
             queryEmbedding: JSON.stringify(queryEmbedding),
@@ -1259,7 +1259,7 @@ self.addEventListener('message', (e) => {
     .bg {
       position: fixed;
       inset: 0;
-      background-image: 
+      background-image:
         radial-gradient(circle at 20% 30%, rgba(139, 92, 246, 0.08) 0%, transparent 50%),
         radial-gradient(circle at 80% 70%, rgba(59, 130, 246, 0.06) 0%, transparent 50%);
       z-index: 0;

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -250,7 +250,7 @@ export const BRAVE_ANSWERS_TOOL: Tool = {
 
 // Analyzes academic research papers using Google's Gemini model.
 // Supports multiple analysis types: summary, critique, literature review, key findings.
-// Requires GOOGLE_API_KEY to be configured.
+// Requires a configured text provider (Gemini, OpenAI, or Anthropic).
 export const RESEARCH_PAPER_ANALYSIS_TOOL: Tool = {
   name: "gemini_research_paper_analysis",
   description:

--- a/src/tools/graphHandlers.ts
+++ b/src/tools/graphHandlers.ts
@@ -34,7 +34,7 @@ import { mergeHandoff, dbToHandoffSchema, sanitizeForMerge } from "../utils/crdt
 // containing: strategy, scores, latency breakdown (embedding/storage/total), and metadata.
 // See src/utils/tracing.ts for full type definitions and design decisions.
 import { createMemoryTrace, traceToContentBlock } from "../utils/tracing.js";
-import { GOOGLE_API_KEY, PRISM_USER_ID, PRISM_AUTO_CAPTURE, PRISM_CAPTURE_PORTS } from "../config.js";
+import { PRISM_USER_ID, PRISM_AUTO_CAPTURE, PRISM_CAPTURE_PORTS } from "../config.js";
 import { captureLocalEnvironment } from "../utils/autoCapture.js";
 import { fireCaptionAsync } from "../utils/imageCaptioner.js";
 import {
@@ -182,7 +182,7 @@ export async function knowledgeSearchHandler(args: unknown) {
     if (resultIds.length > 0) {
       recordMemoryAccess(resultIds);
     }
-    
+
     // Mutate results to surface effective importance
     for (const r of data.results as any[]) {
       if (typeof r.importance === 'number' && r.importance > 0) {
@@ -392,18 +392,6 @@ export async function sessionSearchMemoryHandler(args: unknown) {
   const totalStart = performance.now();
 
   // Step 1: Generate embedding for the search query
-  if (!GOOGLE_API_KEY) {
-    return {
-      content: [{
-        type: "text",
-        text: `❌ Semantic search requires GOOGLE_API_KEY for embedding generation.\n` +
-          `Set this environment variable and restart the server.\n\n` +
-          `💡 As a workaround, try knowledge_search (keyword-based) instead.`,
-      }],
-      isError: true,
-    };
-  }
-
   let queryEmbedding: number[];
   // Phase 1: Start embedding latency timer — isolates Gemini API call time.
   // This is the most variable component: 50ms on a good day, 2000ms under load.
@@ -491,7 +479,7 @@ export async function sessionSearchMemoryHandler(args: unknown) {
           `Tips:\n` +
           `• Lower the similarity_threshold (e.g., 0.5) for broader results\n` +
           `• Try knowledge_search for keyword-based matching\n` +
-          `• Ensure sessions have been saved with embeddings (requires GOOGLE_API_KEY)`,
+          `• Ensure sessions have been saved with embeddings (requires a configured embedding provider)`,
       }];
 
       // Phase 1: Trace is still valuable on empty results — it proves the search
@@ -559,7 +547,7 @@ export async function sessionSearchMemoryHandler(args: unknown) {
           const timestamps = accessTimestamps.length > 0
             ? accessTimestamps
             : [new Date(r.created_at || now)];
-            
+
           // Rollups represent consolidated semantic knowledge over many sessions.
           // They should decay 50% slower than raw episodic chatter to retain long-term context.
           const decayRate = r.is_rollup ? PRISM_ACTR_DECAY * 0.5 : PRISM_ACTR_DECAY;
@@ -1225,9 +1213,9 @@ export async function synthesizeEdgesCore({
 
       for (const match of similar) {
         if (match.id === entry.id) continue;
-        
+
         candidatesEvaluated++;
-        
+
         if (match.similarity < similarity_threshold) {
           belowThreshold++;
           continue;
@@ -1236,7 +1224,7 @@ export async function synthesizeEdgesCore({
         if (neighborsFound >= max_neighbors_per_entry) {
           continue; // We have enough top neighbors above threshold
         }
-        
+
         neighborsFound++;
 
         if (existingTargetIds.has(match.id)) {
@@ -1251,11 +1239,11 @@ export async function synthesizeEdgesCore({
           newLinks++;
         }
       }
-      
+
       totalCandidates += candidatesEvaluated;
       totalBelow += belowThreshold;
     }
-    
+
     return {
       success: true,
       entriesScanned,
@@ -1318,7 +1306,7 @@ export async function sessionSynthesizeEdgesHandler(args: unknown) {
 export async function assembleTestMeContext(nodeId: string, project: string, storage: any) {
   // 1. Gather outbound graph links (top 5)
   const outboundLinks = await storage.getLinksFrom(nodeId, PRISM_USER_ID, 0.0, 5);
-  
+
   // 2. Gather semantic neighbors (top 5) via true search
   const semanticResult = await storage.searchKnowledge({
     project,
@@ -1326,10 +1314,10 @@ export async function assembleTestMeContext(nodeId: string, project: string, sto
     limit: 5,
     userId: PRISM_USER_ID
   });
-  
+
   // 3. Deduplicate and compactly format the results
   const contextMap = new Map<string, string>();
-  
+
   for (const link of outboundLinks) {
     // If the target is an entry, fetch its summary to provide context
     try {
@@ -1341,14 +1329,14 @@ export async function assembleTestMeContext(nodeId: string, project: string, sto
       }
     } catch {}
   }
-  
+
   const semanticEntries = semanticResult?.results || [];
   for (const entry of semanticEntries as any[]) {
     if (entry.id && !contextMap.has(entry.id) && entry.summary) {
       contextMap.set(entry.id, entry.summary.substring(0, 300));
     }
   }
-  
+
   return {
     nodeId,
     project,
@@ -1360,7 +1348,7 @@ export async function generateTestMeQuestions(context: any, nodeId: string) {
   try {
     const provider = getLLMProvider();
 
-    const payloadContext = context.contextItems.length > 0 
+    const payloadContext = context.contextItems.length > 0
       ? context.contextItems.join("\\n---\\n")
       : "No direct graph context available.";
 
@@ -1379,18 +1367,18 @@ Example:
 ]`;
 
     const responseText = await provider.generateText(prompt);
-    
+
     // Attempt to parse strictly
     let textToParse = responseText.trim();
     if (textToParse.startsWith("\`\`\`json")) {
       textToParse = textToParse.replace(/\`\`\`json/g, "").replace(/\`\`\`/g, "").trim();
     }
-    
+
     const parsed = JSON.parse(textToParse);
     if (!Array.isArray(parsed) || parsed.length !== 3 || !parsed[0].q || !parsed[0].a) {
       throw new Error("Invalid output shape");
     }
-    
+
     return { questions: parsed };
   } catch (err: any) {
     if (err.message?.includes("API key") || err.message?.includes("auth")) {

--- a/src/tools/ledgerHandlers.ts
+++ b/src/tools/ledgerHandlers.ts
@@ -38,7 +38,7 @@ import { mergeHandoff, dbToHandoffSchema, sanitizeForMerge } from "../utils/crdt
 // containing: strategy, scores, latency breakdown (embedding/storage/total), and metadata.
 // See src/utils/tracing.ts for full type definitions and design decisions.
 import { createMemoryTrace, traceToContentBlock } from "../utils/tracing.js";
-import { GOOGLE_API_KEY, PRISM_USER_ID, PRISM_AUTO_CAPTURE, PRISM_CAPTURE_PORTS } from "../config.js";
+import { PRISM_USER_ID, PRISM_AUTO_CAPTURE, PRISM_CAPTURE_PORTS } from "../config.js";
 import { captureLocalEnvironment } from "../utils/autoCapture.js";
 import { fireCaptionAsync } from "../utils/imageCaptioner.js";
 import {
@@ -141,7 +141,7 @@ export async function sessionSaveLedgerHandler(args: unknown) {
   });
 
   // ─── Fire-and-forget embedding generation ───
-  if (GOOGLE_API_KEY && result) {
+  if (result) {
     const embeddingText = [summary, ...(decisions || [])].join("\n");
     const savedEntry = Array.isArray(result) ? result[0] : result;
     const entryId = (savedEntry as any)?.id;
@@ -251,7 +251,7 @@ export async function sessionSaveLedgerHandler(args: unknown) {
         (todos?.length ? `TODOs: ${todos.length} items\n` : "") +
         (files_changed?.length ? `Files changed: ${files_changed.length}\n` : "") +
         (decisions?.length ? `Decisions: ${decisions.length}\n` : "") +
-        (GOOGLE_API_KEY ? `📊 Embedding generation queued for semantic search.\n` : "") +
+        `📊 Embedding generation queued for semantic search.\n` +
         repoPathWarning +
         `\nRaw response: ${JSON.stringify(result)}`,
     }],
@@ -520,15 +520,14 @@ export async function sessionSaveHandoffHandler(args: unknown, server?: Server) 
   // merges contradicting facts in the background (~2-3s).
   //
   // TRIGGER CONDITIONS (all must be true):
-  //   1. GOOGLE_API_KEY is configured (Gemini is available)
-  //   2. The handoff was an UPDATE (not a brand-new project)
-  //   3. key_context was provided (something to merge)
+  //   1. The handoff was an UPDATE (not a brand-new project)
+  //   2. key_context was provided (something to merge)
   //
   // OCC SAFETY:
   //   If the user saves another handoff while the merger runs,
   //   the merger's save will fail with a version conflict. This is
   //   intentional — active user input always wins over background merging.
-  if (GOOGLE_API_KEY && data.status === "updated" && key_context) {
+  if (data.status === "updated" && key_context) {
     // Use dynamic import to avoid loading Gemini SDK if not needed
     import("../utils/factMerger.js").then(async ({ consolidateFacts }) => {
       try {
@@ -834,7 +833,7 @@ export async function sessionLoadContextHandler(args: unknown) {
   if (d.last_summary) formattedContext += `📝 Last Summary: ${d.last_summary}\n`;
   if (d.active_branch) formattedContext += `🌿 Active Branch: ${d.active_branch}\n`;
   if (d.key_context) formattedContext += `💡 Key Context: ${d.key_context}\n`;
-  
+
   if (d.pending_todo?.length) {
     formattedContext += `\n✅ Open TODOs:\n` + d.pending_todo.map((t: string) => `  - ${t}`).join("\n") + `\n`;
   }
@@ -901,20 +900,20 @@ export async function sessionLoadContextHandler(args: unknown) {
   // ─── SDM Intuitive Recall (v5.5) ───
   // Generate embedding of current context and fetch latent SDM patterns
   let sdmRecallBlock = "";
-  if (level !== "quick" && GOOGLE_API_KEY) {
+  if (level !== "quick") {
     try {
       const activeText = [d.last_summary, d.key_context, ...(d.keywords || [])].filter(Boolean).join(" ");
       if (activeText.length > 10) {
         // v2.1 LLM factory handles the API call
         const queryVector = await getLLMProvider().generateEmbedding(activeText);
-        
+
         // Lazy-load to avoid blocking server boot
         const { getSdmEngine } = await import("../sdm/sdmEngine.js");
         const { decodeSdmVector } = await import("../sdm/sdmDecoder.js");
 
         const sdmEngine = getSdmEngine(project);
         const targetVector = sdmEngine.read(new Float32Array(queryVector));
-        
+
         const topMatches = await decodeSdmVector(project, targetVector, 3, 0.55);
         if (topMatches.length > 0) {
           sdmRecallBlock = `\n\n[🧠 INTUITIVE RECALL]\nThe deeper Superposed Memory matrix resonated with your current task and surfaced these latent patterns:\n`;
@@ -1381,7 +1380,7 @@ export async function sessionSaveExperienceHandler(args: unknown) {
   });
 
   // Fire-and-forget embedding generation
-  if (GOOGLE_API_KEY && result) {
+  if (result) {
     const embeddingText = summary;
     const savedEntry = Array.isArray(result) ? result[0] : result;
     const entryId = (savedEntry as any)?.id;

--- a/src/utils/factMerger.ts
+++ b/src/utils/factMerger.ts
@@ -29,7 +29,7 @@
  *   "Merge skipped due to active session."
  *
  * REQUIREMENTS:
- *   - GOOGLE_API_KEY must be set (skips gracefully if not)
+ *   - A text provider must be configured (skips gracefully if not)
  *   - Uses gemini-2.5-flash for speed (~2-3s per merge)
  * ═══════════════════════════════════════════════════════════════════
  */

--- a/src/utils/llm/adapters/disabledText.ts
+++ b/src/utils/llm/adapters/disabledText.ts
@@ -10,8 +10,7 @@ export class DisabledTextAdapter implements LLMProvider {
 
   async generateEmbedding(_text: string): Promise<number[]> {
     throw new Error(
-      "[DisabledTextAdapter] generateEmbedding should not be called directly. " +
-      "The factory routes embeddings to LocalEmbeddingAdapter."
+      "[DisabledTextAdapter] Embedding is handled by a separate adapter — this method should not be called directly."
     );
   }
 }

--- a/src/utils/llm/adapters/disabledText.ts
+++ b/src/utils/llm/adapters/disabledText.ts
@@ -1,0 +1,17 @@
+import type { LLMProvider } from "../provider.js";
+
+export class DisabledTextAdapter implements LLMProvider {
+  async generateText(_prompt: string, _systemInstruction?: string): Promise<string> {
+    throw new Error(
+      "Text generation is not available. " +
+      "Configure an AI provider in the Mind Palace dashboard."
+    );
+  }
+
+  async generateEmbedding(_text: string): Promise<number[]> {
+    throw new Error(
+      "[DisabledTextAdapter] generateEmbedding should not be called directly. " +
+      "The factory routes embeddings to LocalEmbeddingAdapter."
+    );
+  }
+}

--- a/src/utils/llm/adapters/local.ts
+++ b/src/utils/llm/adapters/local.ts
@@ -6,9 +6,14 @@ const EMBEDDING_DIMS = 768;
 const MAX_EMBEDDING_CHARS = 8000;
 const DEFAULT_MODEL = "Xenova/nomic-embed-text-v1.5";
 const DEFAULT_REVISION = "main";
+// MODEL_ID_PATTERN allows '.' in the name segment — the separate '..' check below
+// handles directory traversal (e.g., "owner/foo..bar" passes the regex but is invalid).
 const MODEL_ID_PATTERN = /^[a-zA-Z0-9_-]{1,64}\/[a-zA-Z0-9._-]{1,128}$/;
+// Allowed: "main", 40-char commit SHA, semver tag like "v1.5" or "v1.5.0"
+const REVISION_PATTERN = /^(main|[a-f0-9]{40}|v\d+(\.\d+){0,2})$/;
 
 export class LocalEmbeddingAdapter implements LLMProvider {
+  /** @internal Resolves once pipeline initialization completes. Callers and tests await this for readiness. */
   readonly loadPromise: Promise<void>;
   private pipe: ((text: string, opts: object) => Promise<unknown>) | null = null;
   private loadError: Error | null = null;
@@ -44,7 +49,14 @@ export class LocalEmbeddingAdapter implements LLMProvider {
     }
 
     const result = await this.pipe(`search_document: ${inputText}`, { pooling: "mean", normalize: true });
-    const vec = Array.from((result as { data: Float32Array }).data);
+    const tensorData = (result as { data?: Float32Array }).data;
+    if (!tensorData || !(tensorData instanceof Float32Array)) {
+      throw new Error(
+        "[LocalEmbeddingAdapter] Unexpected pipeline output shape — expected { data: Float32Array }. " +
+        "This may indicate an incompatible @huggingface/transformers version."
+      );
+    }
+    const vec = Array.from(tensorData);
 
     if (vec.length !== EMBEDDING_DIMS) {
       throw new Error(
@@ -68,11 +80,20 @@ export class LocalEmbeddingAdapter implements LLMProvider {
     }
 
     const hfEndpoint = process.env.HF_ENDPOINT;
-    if (hfEndpoint && !hfEndpoint.includes("huggingface.co")) {
-      console.warn(
-        `[LocalEmbeddingAdapter] HF_ENDPOINT is set to "${hfEndpoint}" — model downloads are redirected. ` +
-        `Only set if you control and trust this server.`
-      );
+    if (hfEndpoint) {
+      try {
+        const parsed = new URL(hfEndpoint);
+        const isTrusted = parsed.hostname === "huggingface.co" ||
+                          parsed.hostname.endsWith(".huggingface.co");
+        if (!isTrusted) {
+          console.warn(
+            `[LocalEmbeddingAdapter] HF_ENDPOINT hostname "${parsed.hostname}" is not huggingface.co — ` +
+            `model downloads are redirected. Only set if you control and trust this server.`
+          );
+        }
+      } catch {
+        console.warn(`[LocalEmbeddingAdapter] HF_ENDPOINT is not a valid URL: "${hfEndpoint}". Ignoring.`);
+      }
     }
 
     let transformers: typeof import("@huggingface/transformers");
@@ -92,6 +113,14 @@ export class LocalEmbeddingAdapter implements LLMProvider {
     const quantized = getSettingSync("local_embedding_quantized", "true") !== "false";
     const dtype = quantized ? "q8" : "fp32";
     const revision = getSettingSync("local_embedding_revision", DEFAULT_REVISION);
+
+    if (!REVISION_PATTERN.test(revision)) {
+      this.loadError = new Error(
+        `[LocalEmbeddingAdapter] Invalid local_embedding_revision: "${revision}". ` +
+        `Allowed values: "main", a 40-char commit SHA, or a semver tag like "v1.5".`
+      );
+      return;
+    }
 
     try {
       const pipelineInstance = await transformers.pipeline("feature-extraction", model, { dtype, revision } as Parameters<typeof transformers.pipeline>[2]);

--- a/src/utils/llm/adapters/local.ts
+++ b/src/utils/llm/adapters/local.ts
@@ -1,0 +1,115 @@
+import { getSettingSync } from "../../../storage/configStorage.js";
+import { debugLog } from "../../logger.js";
+import type { LLMProvider } from "../provider.js";
+
+const EMBEDDING_DIMS = 768;
+const MAX_EMBEDDING_CHARS = 8000;
+const DEFAULT_MODEL = "Xenova/nomic-embed-text-v1.5";
+const DEFAULT_REVISION = "main";
+const MODEL_ID_PATTERN = /^[a-zA-Z0-9_-]{1,64}\/[a-zA-Z0-9._-]{1,128}$/;
+
+export class LocalEmbeddingAdapter implements LLMProvider {
+  readonly loadPromise: Promise<void>;
+  private pipe: ((text: string, opts: object) => Promise<unknown>) | null = null;
+  private loadError: Error | null = null;
+
+  constructor() {
+    this.loadPromise = this.initPipeline();
+  }
+
+  async generateText(_prompt: string, _systemInstruction?: string): Promise<string> {
+    throw new Error(
+      "LocalEmbeddingAdapter does not support text generation. " +
+      "It is an embedding-only provider. Configure a text provider in the Mind Palace dashboard."
+    );
+  }
+
+  async generateEmbedding(text: string): Promise<number[]> {
+    if (!text || !text.trim()) {
+      throw new Error("[LocalEmbeddingAdapter] generateEmbedding called with empty text");
+    }
+
+    let inputText = text;
+    if (inputText.length > MAX_EMBEDDING_CHARS) {
+      inputText = inputText.substring(0, MAX_EMBEDDING_CHARS);
+      const lastSpace = inputText.lastIndexOf(" ");
+      if (lastSpace > 0) inputText = inputText.substring(0, lastSpace);
+    }
+
+    await this.loadPromise;
+
+    if (this.loadError) throw this.loadError;
+    if (!this.pipe) {
+      throw new Error("[LocalEmbeddingAdapter] Pipeline not initialized and no load error recorded");
+    }
+
+    const result = await this.pipe(`search_document: ${inputText}`, { pooling: "mean", normalize: true });
+    const vec = Array.from((result as { data: Float32Array }).data);
+
+    if (vec.length !== EMBEDDING_DIMS) {
+      throw new Error(
+        `[LocalEmbeddingAdapter] Embedding dimension mismatch: expected ${EMBEDDING_DIMS}, got ${vec.length}. ` +
+        `Check the local_embedding_model setting.`
+      );
+    }
+
+    return vec;
+  }
+
+  private async initPipeline(): Promise<void> {
+    const model = process.env.LOCAL_EMBEDDING_MODEL ?? getSettingSync("local_embedding_model", DEFAULT_MODEL);
+
+    if (!MODEL_ID_PATTERN.test(model) || model.includes("..")) {
+      this.loadError = new Error(
+        `[LocalEmbeddingAdapter] Invalid local_embedding_model: "${model}". ` +
+        `Must be a HuggingFace model ID in "owner/name" format.`
+      );
+      return;
+    }
+
+    const hfEndpoint = process.env.HF_ENDPOINT;
+    if (hfEndpoint && !hfEndpoint.includes("huggingface.co")) {
+      console.warn(
+        `[LocalEmbeddingAdapter] HF_ENDPOINT is set to "${hfEndpoint}" — model downloads are redirected. ` +
+        `Only set if you control and trust this server.`
+      );
+    }
+
+    let transformers: typeof import("@huggingface/transformers");
+    try {
+      transformers = await import("@huggingface/transformers");
+    } catch (err) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      this.loadError = (e as NodeJS.ErrnoException).code === "ERR_MODULE_NOT_FOUND"
+        ? new Error(
+            "[LocalEmbeddingAdapter] @huggingface/transformers is not installed. " +
+            "Run: npm install @huggingface/transformers"
+          )
+        : e;
+      return;
+    }
+
+    const quantized = getSettingSync("local_embedding_quantized", "true") !== "false";
+    const dtype = quantized ? "q8" : "fp32";
+    const revision = getSettingSync("local_embedding_revision", DEFAULT_REVISION);
+
+    try {
+      const pipelineInstance = await transformers.pipeline("feature-extraction", model, { dtype, revision } as Parameters<typeof transformers.pipeline>[2]);
+      this.pipe = pipelineInstance as (text: string, opts: object) => Promise<unknown>;
+
+      try {
+        await this.pipe("warmup text", { pooling: "mean", normalize: true });
+        debugLog(`[LocalEmbeddingAdapter] Pipeline ready and warmed up: ${model} (${dtype})`);
+      } catch (warmupErr) {
+        const we = warmupErr instanceof Error ? warmupErr : new Error(String(warmupErr));
+        console.warn(
+          `[LocalEmbeddingAdapter] Warmup failed (non-fatal): ${we.message}. ` +
+          `First embedding call may be slightly slower.`
+        );
+      }
+    } catch (err) {
+      this.loadError = err instanceof Error ? err : new Error(String(err));
+      console.error(`[LocalEmbeddingAdapter] Failed to load pipeline: ${this.loadError.message}`);
+    }
+  }
+}

--- a/src/utils/llm/adapters/local.ts
+++ b/src/utils/llm/adapters/local.ts
@@ -4,7 +4,7 @@ import type { LLMProvider } from "../provider.js";
 
 const EMBEDDING_DIMS = 768;
 const MAX_EMBEDDING_CHARS = 8000;
-const DEFAULT_MODEL = "Xenova/nomic-embed-text-v1.5";
+const DEFAULT_MODEL = "nomic-ai/nomic-embed-text-v1.5";
 const DEFAULT_REVISION = "main";
 // MODEL_ID_PATTERN allows '.' in the name segment — the separate '..' check below
 // handles directory traversal (e.g., "owner/foo..bar" passes the regex but is invalid).

--- a/src/utils/llm/factory.ts
+++ b/src/utils/llm/factory.ts
@@ -11,7 +11,7 @@
  *   Two independent settings control text and embedding routing:
  *
  *   text_provider      — "gemini" (default) | "openai" | "anthropic"
- *   embedding_provider — "auto" (default)   | "gemini" | "openai" | "voyage"
+ *   embedding_provider — "auto" (default)   | "gemini" | "openai" | "voyage" | "local"
  *
  *   When embedding_provider = "auto":
  *     * If text_provider is gemini or openai → use same provider for embeddings

--- a/src/utils/llm/factory.ts
+++ b/src/utils/llm/factory.ts
@@ -46,6 +46,8 @@ import { GeminiAdapter } from "./adapters/gemini.js";
 import { OpenAIAdapter } from "./adapters/openai.js";
 import { AnthropicAdapter } from "./adapters/anthropic.js";
 import { VoyageAdapter } from "./adapters/voyage.js";
+import { LocalEmbeddingAdapter } from "./adapters/local.js";
+import { DisabledTextAdapter } from "./adapters/disabledText.js";
 import { TracingLLMProvider } from "./adapters/traced.js";
 
 // Module-level singleton — one composed provider per MCP server process.
@@ -59,6 +61,7 @@ function buildTextAdapter(type: string): LLMProvider {
   switch (type) {
     case "anthropic": return new AnthropicAdapter();
     case "openai":    return new OpenAIAdapter();
+    case "none":      return new DisabledTextAdapter();
     case "gemini":
     default:          return new GeminiAdapter();
   }
@@ -72,6 +75,7 @@ function buildEmbeddingAdapter(type: string): LLMProvider {
   switch (type) {
     case "openai": return new OpenAIAdapter();
     case "voyage": return new VoyageAdapter();
+    case "local":  return new LocalEmbeddingAdapter();
     case "gemini":
     default:       return new GeminiAdapter();
   }

--- a/tests/llm/factory.test.ts
+++ b/tests/llm/factory.test.ts
@@ -85,7 +85,7 @@ vi.mock("../../src/utils/llm/adapters/disabledText.js", () => ({
       new Error("Text generation is not available")
     );
     this.generateEmbedding = vi.fn().mockRejectedValue(
-      new Error("[DisabledTextAdapter] generateEmbedding should not be called directly")
+      new Error("[DisabledTextAdapter] Embedding is handled by a separate adapter")
     );
   }),
 }));

--- a/tests/llm/factory.test.ts
+++ b/tests/llm/factory.test.ts
@@ -1,5 +1,5 @@
 /**
- * LLM Provider Factory — Split Provider Tests (v4.5 Voyage AI)
+ * LLM Provider Factory — Split Provider Tests (v4.5 Voyage AI + v9.5 LocalEmbeddingAdapter)
  *
  * Validates the factory's text_provider + embedding_provider composition logic
  * without making real API calls. Uses _resetLLMProvider() between tests.
@@ -11,6 +11,10 @@
  *
  * v4.5 Voyage AI:
  *   embedding_provider=voyage → uses VoyageAdapter (Anthropic-recommended pairing)
+ *
+ * v9.5 Local Embeddings:
+ *   embedding_provider=local → uses LocalEmbeddingAdapter (no API key required)
+ *   text_provider=none       → uses DisabledTextAdapter (local-only setup)
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
@@ -19,6 +23,8 @@ import { GeminiAdapter } from "../../src/utils/llm/adapters/gemini.js";
 import { OpenAIAdapter } from "../../src/utils/llm/adapters/openai.js";
 import { AnthropicAdapter } from "../../src/utils/llm/adapters/anthropic.js";
 import { VoyageAdapter } from "../../src/utils/llm/adapters/voyage.js";
+import { LocalEmbeddingAdapter } from "../../src/utils/llm/adapters/local.js";
+import { DisabledTextAdapter } from "../../src/utils/llm/adapters/disabledText.js";
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 // We mock getSettingSync so tests don't need a real SQLite DB.
@@ -63,9 +69,32 @@ vi.mock("../../src/utils/llm/adapters/voyage.js", () => ({
   }),
 }));
 
+vi.mock("../../src/utils/llm/adapters/local.js", () => ({
+  LocalEmbeddingAdapter: vi.fn(function (this: any) {
+    this.generateEmbedding = vi.fn();
+    this.generateText = vi.fn().mockRejectedValue(
+      new Error("LocalEmbeddingAdapter does not support text generation")
+    );
+    this.loadPromise = Promise.resolve();
+  }),
+}));
+
+vi.mock("../../src/utils/llm/adapters/disabledText.js", () => ({
+  DisabledTextAdapter: vi.fn(function (this: any) {
+    this.generateText = vi.fn().mockRejectedValue(
+      new Error("Text generation is not available")
+    );
+    this.generateEmbedding = vi.fn().mockRejectedValue(
+      new Error("[DisabledTextAdapter] generateEmbedding should not be called directly")
+    );
+  }),
+}));
+
 import { getSettingSync } from "../../src/storage/configStorage.js";
 const mockGetSettingSync = vi.mocked(getSettingSync);
 const mockVoyageAdapter = vi.mocked(VoyageAdapter);
+const mockLocalEmbeddingAdapter = vi.mocked(LocalEmbeddingAdapter);
+const mockDisabledTextAdapter = vi.mocked(DisabledTextAdapter);
 
 // Helper: mock both text_provider and embedding_provider together
 function mockProviders(text: string, embedding = "auto", extras: Record<string, string> = {}) {
@@ -197,6 +226,30 @@ describe("LLM Provider Factory — Split Architecture", () => {
     expect(infoSpy).toHaveBeenCalledWith(
       expect.stringContaining("embedding_provider=voyage")
     );
+    infoSpy.mockRestore();
+  });
+
+  // ── Local embedding provider ──────────────────────────────────────────────
+
+  it("embedding_provider=local → LocalEmbeddingAdapter for embeddings", () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    mockProviders("gemini", "local");
+    getLLMProvider();
+    expect(mockLocalEmbeddingAdapter).toHaveBeenCalledOnce();
+    expect(GeminiAdapter).toHaveBeenCalledOnce(); // text only
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Split provider: text=gemini, embedding=local")
+    );
+    infoSpy.mockRestore();
+  });
+
+  it("text_provider=none, embedding_provider=local → DisabledTextAdapter + LocalEmbeddingAdapter", () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    mockProviders("none", "local");
+    getLLMProvider();
+    expect(mockDisabledTextAdapter).toHaveBeenCalledOnce();
+    expect(mockLocalEmbeddingAdapter).toHaveBeenCalledOnce();
+    expect(GeminiAdapter).not.toHaveBeenCalled();
     infoSpy.mockRestore();
   });
 

--- a/tests/llm/local-missing-dep.test.ts
+++ b/tests/llm/local-missing-dep.test.ts
@@ -38,7 +38,7 @@ vi.mock("@huggingface/transformers", () => ({
   }),
 }));
 
-describe("LocalEmbeddingAdapter — broken transformers.js install", () => {
+describe("LocalEmbeddingAdapter — broken/corrupted transformers.js install", () => {
   it("loadPromise resolves (non-fatal) even when pipeline construction fails", async () => {
     const { LocalEmbeddingAdapter } = await import("../../src/utils/llm/adapters/local.js");
     const adapter = new LocalEmbeddingAdapter();

--- a/tests/llm/local-missing-dep.test.ts
+++ b/tests/llm/local-missing-dep.test.ts
@@ -1,0 +1,57 @@
+/**
+ * LocalEmbeddingAdapter — broken/missing transformers.js
+ *
+ * Tests behaviour when @huggingface/transformers fails to load or is unavailable.
+ *
+ * Note: vitest wraps vi.mock factory errors with its own message, so we cannot
+ * reliably simulate ERR_MODULE_NOT_FOUND by throwing from the factory. Instead
+ * we mock the module to have a pipeline that throws on construction — which
+ * exercises the same loadError → generateEmbedding-throws path that a missing
+ * module would produce, just via a slightly different error code.
+ *
+ * Real-world ERR_MODULE_NOT_FOUND (user hasn't run `npm install
+ * @huggingface/transformers`) is covered by the friendly error message in
+ * local.ts which is verified in local.test.ts under "Pipeline failure".
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+// ─── Mock: configStorage ─────────────────────────────────────────────────────
+vi.mock("../../src/storage/configStorage.js", () => ({
+  getSettingSync: vi.fn((_key: string, defaultValue?: string) => defaultValue ?? ""),
+}));
+
+// ─── Mock: logger ─────────────────────────────────────────────────────────────
+vi.mock("../../src/utils/logger.js", () => ({
+  debugLog: vi.fn(),
+}));
+
+// ─── Mock: transformers module with broken pipeline ───────────────────────────
+// Simulates a corrupted or incompatible install. The import succeeds but
+// pipeline() throws — exercising the same loadError path as a missing dep.
+vi.mock("@huggingface/transformers", () => ({
+  pipeline: vi.fn(() => {
+    throw Object.assign(
+      new Error("Cannot find module '@huggingface/transformers'"),
+      { code: "ERR_MODULE_NOT_FOUND" },
+    );
+  }),
+}));
+
+describe("LocalEmbeddingAdapter — broken transformers.js install", () => {
+  it("loadPromise resolves (non-fatal) even when pipeline construction fails", async () => {
+    const { LocalEmbeddingAdapter } = await import("../../src/utils/llm/adapters/local.js");
+    const adapter = new LocalEmbeddingAdapter();
+    // Must resolve, not reject — a crashed pipeline should not crash the server
+    await expect(adapter.loadPromise).resolves.toBeUndefined();
+  });
+
+  it("generateEmbedding throws with the pipeline's error message", async () => {
+    const { LocalEmbeddingAdapter } = await import("../../src/utils/llm/adapters/local.js");
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    await expect(adapter.generateEmbedding("test")).rejects.toThrow(
+      /Cannot find module/,
+    );
+  });
+});

--- a/tests/llm/local.test.ts
+++ b/tests/llm/local.test.ts
@@ -1,0 +1,275 @@
+/**
+ * LocalEmbeddingAdapter Tests
+ *
+ * Tests the local transformers.js embedding adapter.
+ * Uses vi.mock to intercept @huggingface/transformers so no model is downloaded.
+ *
+ * For ERR_MODULE_NOT_FOUND (missing dep) scenarios, see local-missing-dep.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { LocalEmbeddingAdapter as LocalEmbeddingAdapterType } from "../../src/utils/llm/adapters/local.js";
+
+// ─── Mock: configStorage ─────────────────────────────────────────────────────
+vi.mock("../../src/storage/configStorage.js", () => ({
+  getSettingSync: vi.fn((key: string, defaultValue?: string) => defaultValue ?? ""),
+}));
+
+// ─── Mock: logger ─────────────────────────────────────────────────────────────
+vi.mock("../../src/utils/logger.js", () => ({
+  debugLog: vi.fn(),
+}));
+
+// ─── Fake tensor factory ──────────────────────────────────────────────────────
+// Builds a fake transformer pipeline that returns a Float32Array of the given length.
+function makeFakePipeline(dims = 768) {
+  return vi.fn().mockResolvedValue({ data: new Float32Array(dims) });
+}
+
+// ─── Mock: @huggingface/transformers ─────────────────────────────────────────
+const mockPipelineFn = makeFakePipeline(768);
+const mockPipelineFactory = vi.fn().mockResolvedValue(mockPipelineFn);
+
+vi.mock("@huggingface/transformers", () => ({
+  pipeline: mockPipelineFactory,
+}));
+
+import { getSettingSync } from "../../src/storage/configStorage.js";
+const mockGetSettingSync = vi.mocked(getSettingSync);
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function mockSettings(overrides: Record<string, string> = {}) {
+  mockGetSettingSync.mockImplementation((key: string, def?: string) => {
+    return overrides[key] ?? def ?? "";
+  });
+}
+
+async function makeAdapter(): Promise<LocalEmbeddingAdapterType> {
+  const { LocalEmbeddingAdapter } = await import("../../src/utils/llm/adapters/local.js");
+  return new LocalEmbeddingAdapter();
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("LocalEmbeddingAdapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reuse the same mockPipelineFn so test assertions on it remain valid
+    mockPipelineFactory.mockResolvedValue(mockPipelineFn);
+    mockPipelineFn.mockResolvedValue({ data: new Float32Array(768) });
+  });
+
+  // ── Construction ───────────────────────────────────────────────────────────
+
+  it("exposes a loadPromise property on construction", async () => {
+    mockSettings();
+    const adapter = await makeAdapter();
+    expect(adapter.loadPromise).toBeInstanceOf(Promise);
+  });
+
+  it("construction is synchronous (loadPromise is a fire-and-forget)", async () => {
+    mockSettings();
+    let constructed = false;
+    const { LocalEmbeddingAdapter } = await import("../../src/utils/llm/adapters/local.js");
+    new LocalEmbeddingAdapter();
+    constructed = true;
+    expect(constructed).toBe(true); // constructor returned without awaiting
+  });
+
+  // ── generateText ───────────────────────────────────────────────────────────
+
+  it("generateText throws — LocalEmbeddingAdapter is embedding-only", async () => {
+    mockSettings();
+    const adapter = await makeAdapter();
+    await expect(adapter.generateText("hello")).rejects.toThrow(
+      /does not support text generation/
+    );
+  });
+
+  // ── Model ID validation ────────────────────────────────────────────────────
+
+  it("sets loadError when model ID is invalid (path traversal attempt)", async () => {
+    mockSettings({ local_embedding_model: "../../etc/passwd" });
+    const adapter = await makeAdapter();
+    await adapter.loadPromise;
+    await expect(adapter.generateEmbedding("test")).rejects.toThrow(
+      /Invalid local_embedding_model/
+    );
+  });
+
+  it("sets loadError when model ID contains '..' (directory traversal)", async () => {
+    mockSettings({ local_embedding_model: "owner/foo..bar" });
+    const adapter = await makeAdapter();
+    await adapter.loadPromise;
+    await expect(adapter.generateEmbedding("test")).rejects.toThrow(
+      /Invalid local_embedding_model/
+    );
+  });
+
+  it("sets loadError when model ID has no slash", async () => {
+    mockSettings({ local_embedding_model: "nodeslash" });
+    const adapter = await makeAdapter();
+    await adapter.loadPromise;
+    await expect(adapter.generateEmbedding("test")).rejects.toThrow(
+      /Invalid local_embedding_model/
+    );
+  });
+
+  // ── Happy path ────────────────────────────────────────────────────────────
+
+  it("returns a 768-element number array for valid text", async () => {
+    mockSettings();
+    const adapter = await makeAdapter();
+    await adapter.loadPromise;
+    const vec = await adapter.generateEmbedding("hello world");
+    expect(vec).toHaveLength(768);
+    expect(typeof vec[0]).toBe("number");
+  });
+
+  it("prepends 'search_document: ' prefix before calling the pipeline", async () => {
+    mockSettings();
+    const adapter = await makeAdapter();
+    await adapter.loadPromise;
+    await adapter.generateEmbedding("my text");
+    expect(mockPipelineFn).toHaveBeenCalledWith(
+      "search_document: my text",
+      { pooling: "mean", normalize: true }
+    );
+  });
+
+  it("passes pooling=mean and normalize=true to the pipeline", async () => {
+    mockSettings();
+    const adapter = await makeAdapter();
+    await adapter.loadPromise;
+    await adapter.generateEmbedding("any input");
+    // Last call is the real embedding (warmup is first); check opts
+    const lastCall = mockPipelineFn.mock.calls.at(-1)!;
+    expect(lastCall[1]).toEqual({ pooling: "mean", normalize: true });
+  });
+
+  it("converts Float32Array tensor to plain number[]", async () => {
+    mockSettings();
+    const adapter = await makeAdapter();
+    await adapter.loadPromise;
+    const vec = await adapter.generateEmbedding("test");
+    expect(Array.isArray(vec)).toBe(true);
+    expect(vec).not.toBeInstanceOf(Float32Array);
+  });
+
+  it("initialises pipeline with dtype='q8' by default", async () => {
+    mockSettings();
+    const adapter = await makeAdapter();
+    await adapter.loadPromise;
+    expect(mockPipelineFactory).toHaveBeenCalledWith(
+      "feature-extraction",
+      expect.any(String),
+      expect.objectContaining({ dtype: "q8" })
+    );
+  });
+
+  it("uses dtype='fp32' when local_embedding_quantized=false", async () => {
+    mockSettings({ local_embedding_quantized: "false" });
+    const adapter = await makeAdapter();
+    await adapter.loadPromise;
+    expect(mockPipelineFactory).toHaveBeenCalledWith(
+      "feature-extraction",
+      expect.any(String),
+      expect.objectContaining({ dtype: "fp32" })
+    );
+  });
+
+  // ── Empty/whitespace guard ─────────────────────────────────────────────────
+
+  it("throws on empty string input", async () => {
+    mockSettings();
+    const adapter = await makeAdapter();
+    await adapter.loadPromise;
+    await expect(adapter.generateEmbedding("")).rejects.toThrow(
+      /empty text/
+    );
+  });
+
+  it("throws on whitespace-only input", async () => {
+    mockSettings();
+    const adapter = await makeAdapter();
+    await adapter.loadPromise;
+    await expect(adapter.generateEmbedding("   ")).rejects.toThrow(
+      /empty text/
+    );
+  });
+
+  // ── Truncation ────────────────────────────────────────────────────────────
+
+  it("truncates text longer than 8000 chars at a word boundary", async () => {
+    mockSettings();
+    const adapter = await makeAdapter();
+    await adapter.loadPromise;
+    const long = "word ".repeat(2000); // 10000 chars
+    await adapter.generateEmbedding(long);
+    const calledText: string = mockPipelineFn.mock.calls.at(-1)![0];
+    // Strip the "search_document: " prefix before checking length
+    const inputPart = calledText.replace("search_document: ", "");
+    expect(inputPart.length).toBeLessThanOrEqual(8000);
+    expect(inputPart.endsWith(" ")).toBe(false); // trimmed at word boundary
+  });
+
+  // ── Dimension guard ───────────────────────────────────────────────────────
+
+  it("throws when pipeline returns wrong dimension count", async () => {
+    mockPipelineFactory.mockResolvedValueOnce(makeFakePipeline(384)); // wrong dims
+    mockSettings();
+    const { LocalEmbeddingAdapter } = await import("../../src/utils/llm/adapters/local.js");
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    await expect(adapter.generateEmbedding("test")).rejects.toThrow(
+      /Embedding dimension mismatch/
+    );
+  });
+
+  // ── Pipeline failure ──────────────────────────────────────────────────────
+
+  it("propagates pipeline init errors through generateEmbedding", async () => {
+    mockPipelineFactory.mockRejectedValueOnce(new Error("network error"));
+    mockSettings();
+    const { LocalEmbeddingAdapter } = await import("../../src/utils/llm/adapters/local.js");
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    await expect(adapter.generateEmbedding("test")).rejects.toThrow("network error");
+  });
+
+  // ── Warmup non-fatal ──────────────────────────────────────────────────────
+
+  it("warmup failure is non-fatal — loadPromise resolves and embed works", async () => {
+    // First call (warmup) throws, second call (real embed) succeeds
+    const warmupThrowsPipe = vi.fn()
+      .mockRejectedValueOnce(new Error("warmup error"))
+      .mockResolvedValueOnce({ data: new Float32Array(768) });
+    mockPipelineFactory.mockResolvedValueOnce(warmupThrowsPipe);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockSettings();
+    const { LocalEmbeddingAdapter } = await import("../../src/utils/llm/adapters/local.js");
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise; // should resolve, not reject
+    const vec = await adapter.generateEmbedding("post-warmup text");
+    expect(vec).toHaveLength(768);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Warmup failed"));
+    warnSpy.mockRestore();
+  });
+
+  // ── HF_ENDPOINT warning ───────────────────────────────────────────────────
+
+  it("warns when HF_ENDPOINT points to a non-huggingface.co host", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const originalEnv = process.env.HF_ENDPOINT;
+    process.env.HF_ENDPOINT = "https://evil.example.com";
+    mockSettings();
+    const { LocalEmbeddingAdapter } = await import("../../src/utils/llm/adapters/local.js");
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("HF_ENDPOINT"));
+    warnSpy.mockRestore();
+    if (originalEnv === undefined) delete process.env.HF_ENDPOINT;
+    else process.env.HF_ENDPOINT = originalEnv;
+  });
+});

--- a/tests/llm/local.test.ts
+++ b/tests/llm/local.test.ts
@@ -58,6 +58,11 @@ describe("LocalEmbeddingAdapter", () => {
     // Reuse the same mockPipelineFn so test assertions on it remain valid
     mockPipelineFactory.mockResolvedValue(mockPipelineFn);
     mockPipelineFn.mockResolvedValue({ data: new Float32Array(768) });
+    // Prevent env-var pollution between tests. HF_ENDPOINT and
+    // LOCAL_EMBEDDING_MODEL are read by initPipeline() — if a prior test
+    // failed before its inline cleanup ran, these would leak.
+    delete process.env.HF_ENDPOINT;
+    delete process.env.LOCAL_EMBEDDING_MODEL;
   });
 
   // ── Construction ───────────────────────────────────────────────────────────
@@ -261,7 +266,6 @@ describe("LocalEmbeddingAdapter", () => {
 
   it("warns when HF_ENDPOINT points to a non-huggingface.co host", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const originalEnv = process.env.HF_ENDPOINT;
     process.env.HF_ENDPOINT = "https://evil.example.com";
     mockSettings();
     const { LocalEmbeddingAdapter } = await import("../../src/utils/llm/adapters/local.js");
@@ -269,13 +273,10 @@ describe("LocalEmbeddingAdapter", () => {
     await adapter.loadPromise;
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("HF_ENDPOINT"));
     warnSpy.mockRestore();
-    if (originalEnv === undefined) delete process.env.HF_ENDPOINT;
-    else process.env.HF_ENDPOINT = originalEnv;
   });
 
   it("warns when HF_ENDPOINT is a subdomain-spoofing URL (huggingface.co.evil.com)", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const originalEnv = process.env.HF_ENDPOINT;
     process.env.HF_ENDPOINT = "https://huggingface.co.evil.com";
     mockSettings();
     const { LocalEmbeddingAdapter } = await import("../../src/utils/llm/adapters/local.js");
@@ -283,13 +284,10 @@ describe("LocalEmbeddingAdapter", () => {
     await adapter.loadPromise;
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("HF_ENDPOINT"));
     warnSpy.mockRestore();
-    if (originalEnv === undefined) delete process.env.HF_ENDPOINT;
-    else process.env.HF_ENDPOINT = originalEnv;
   });
 
   it("does NOT warn when HF_ENDPOINT is a trusted huggingface.co subdomain", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const originalEnv = process.env.HF_ENDPOINT;
     process.env.HF_ENDPOINT = "https://endpoints.huggingface.co";
     mockSettings();
     const { LocalEmbeddingAdapter } = await import("../../src/utils/llm/adapters/local.js");
@@ -297,8 +295,6 @@ describe("LocalEmbeddingAdapter", () => {
     await adapter.loadPromise;
     expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining("HF_ENDPOINT"));
     warnSpy.mockRestore();
-    if (originalEnv === undefined) delete process.env.HF_ENDPOINT;
-    else process.env.HF_ENDPOINT = originalEnv;
   });
 
   // ── Revision validation ───────────────────────────────────────────────────

--- a/tests/llm/local.test.ts
+++ b/tests/llm/local.test.ts
@@ -272,4 +272,74 @@ describe("LocalEmbeddingAdapter", () => {
     if (originalEnv === undefined) delete process.env.HF_ENDPOINT;
     else process.env.HF_ENDPOINT = originalEnv;
   });
+
+  it("warns when HF_ENDPOINT is a subdomain-spoofing URL (huggingface.co.evil.com)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const originalEnv = process.env.HF_ENDPOINT;
+    process.env.HF_ENDPOINT = "https://huggingface.co.evil.com";
+    mockSettings();
+    const { LocalEmbeddingAdapter } = await import("../../src/utils/llm/adapters/local.js");
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("HF_ENDPOINT"));
+    warnSpy.mockRestore();
+    if (originalEnv === undefined) delete process.env.HF_ENDPOINT;
+    else process.env.HF_ENDPOINT = originalEnv;
+  });
+
+  it("does NOT warn when HF_ENDPOINT is a trusted huggingface.co subdomain", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const originalEnv = process.env.HF_ENDPOINT;
+    process.env.HF_ENDPOINT = "https://endpoints.huggingface.co";
+    mockSettings();
+    const { LocalEmbeddingAdapter } = await import("../../src/utils/llm/adapters/local.js");
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining("HF_ENDPOINT"));
+    warnSpy.mockRestore();
+    if (originalEnv === undefined) delete process.env.HF_ENDPOINT;
+    else process.env.HF_ENDPOINT = originalEnv;
+  });
+
+  // ── Revision validation ───────────────────────────────────────────────────
+
+  it("sets loadError when local_embedding_revision is an invalid format", async () => {
+    mockSettings({ local_embedding_revision: "../../malicious-branch" });
+    const { LocalEmbeddingAdapter } = await import("../../src/utils/llm/adapters/local.js");
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    await expect(adapter.generateEmbedding("test")).rejects.toThrow(
+      /Invalid local_embedding_revision/
+    );
+  });
+
+  it("accepts valid revision values: main, v1.5, 40-char SHA", async () => {
+    const validRevisions = [
+      "main",
+      "v1.5",
+      "v1.5.0",
+      "a".repeat(40), // 40-char hex SHA
+    ];
+    for (const rev of validRevisions) {
+      mockSettings({ local_embedding_revision: rev });
+      const { LocalEmbeddingAdapter } = await import("../../src/utils/llm/adapters/local.js");
+      const adapter = new LocalEmbeddingAdapter();
+      await adapter.loadPromise;
+      await expect(adapter.generateEmbedding("test")).resolves.toHaveLength(768);
+    }
+  });
+
+  // ── Tensor null guard ─────────────────────────────────────────────────────
+
+  it("throws a descriptive error when pipeline returns result with no data property", async () => {
+    const nullDataPipe = vi.fn().mockResolvedValue({ data: undefined }); // no data
+    mockPipelineFactory.mockResolvedValueOnce(nullDataPipe);
+    mockSettings();
+    const { LocalEmbeddingAdapter } = await import("../../src/utils/llm/adapters/local.js");
+    const adapter = new LocalEmbeddingAdapter();
+    await adapter.loadPromise;
+    await expect(adapter.generateEmbedding("test")).rejects.toThrow(
+      /Unexpected pipeline output shape/
+    );
+  });
 });


### PR DESCRIPTION
## Summary

This PR brings our fork up to date with the original [dcostenco/prism-mcp](https://github.com/dcostenco/prism-mcp) repo. We were stuck at v9.4.6 — this pulls in everything from v9.4.7 through v9.12.0 (34 commits).

**None of our local-embeddings changes are lost.** This is a merge, not a rebase — our code (LocalEmbeddingAdapter, DisabledTextAdapter, removed GOOGLE_API_KEY guards) stays intact alongside the new upstream work.

## What's coming in from upstream

The upstream author has been focused on **security hardening and behavioral testing** since we forked. Here's what the 34 commits break down to:

### ABA Precision Protocol (behavioral testing framework)
A new test suite that validates how Prism's AI responses behave — things like "don't apologize unnecessarily," "help first before asking questions," "fix without asking." Started at 43 tests, grew to 482. This doesn't affect our embeddings work but makes the overall system more robust.

### Security hardening (multiple rounds)
- **Stored prompt injection prevention** — stops malicious content saved in memory from hijacking future sessions
- **Output guardrails** — IF/THEN prompt patterns that constrain responses
- **Adversarial review** — 24 forbidden response openers, expanded rules
- **Domain whitelist** and **sliding window buffer** for safer content handling

### Bug fixes
- **Split-brain detection** — false warning when Supabase is the authoritative source (14 new tests)
- **Buffer flush fix** for edge cases

### Housekeeping
- Repomix gitignore consolidation
- Version bumps and changelog updates

## Merge conflicts resolved

Only one conflict: `package-lock.json`. Resolved by accepting the upstream version and running `npm install` to regenerate with our `@huggingface/transformers` dependency included.

## What to check after merging

- `npm install` should work cleanly
- Local embeddings should still work (`embedding_provider=local`)
- The dashboard should load without issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)