### PR TITLE
fix(sqlite): allow embedding filter column so backfill works on SQLite

### DIFF
--- a/src/storage/sqlite.ts
+++ b/src/storage/sqlite.ts
@@ -837,7 +837,7 @@ export class SqliteStorage implements StorageBackend {
     "id", "project", "user_id", "conversation_id", "summary",
     "archived_at", "deleted_at", "is_rollup", "role", "event_type",
     "created_at", "updated_at", "session_date", "importance", "title",
-    "agent_name", "last_accessed_at", "confidence_score", "rollup_count",
+    "agent_name", "last_accessed_at", "confidence_score", "rollup_count", "embedding",
   ]);
 
   private parsePostgRESTFilters(

--- a/tests/storage/sqlite-filter-injection.test.ts
+++ b/tests/storage/sqlite-filter-injection.test.ts
@@ -75,6 +75,10 @@ describe("Bug 8.1 — allowed columns pass through without throwing", () => {
     expect(() => parse({ archived_at: "is.null" })).not.toThrow();
   });
 
+  it("allows embedding is.null filter", () => {
+    expect(() => parse({ embedding: "is.null" })).not.toThrow();
+  });
+
   it("allows importance gt filter", () => {
     expect(() => parse({ importance: "gt.0.5" })).not.toThrow();
   });


### PR DESCRIPTION
The embedding backfill is broken on the SQLite backend (#94).

Short version: `backfillEmbeddingsHandler` (`src/tools/hygieneHandlers.ts`) finds rows to embed
with an `embedding=is.null` filter, but `parsePostgRESTFilters` in `src/storage/sqlite.ts` checks
every filter key against `ALLOWED_FILTER_COLUMNS` and `embedding` wasn't in the set, so it threw
`rejected unknown filter column "embedding"` before the query ran. `session_backfill_embeddings`
threw and `session_health_check(auto_fix)` repaired 0 rows. The `is.null` operator was already fine
(`archived_at` uses it), so the only thing missing was the allowlist entry. Supabase takes the
filter natively and was never affected.

So this just adds `"embedding"` to the allowlist. SQLite-only; embedding search and generation for
new writes were never affected.

Testing:

- `npm run build` and `npm test` pass.
- Added a regression assertion in `tests/storage/sqlite-filter-injection.test.ts`
  (`parse({ embedding: "is.null" })` no longer throws). Checked that it fails without the change
  and passes with it.
- Locally, with SQLite rows that had a NULL `embedding`, backfill now finds and embeds them instead
  of throwing, and `session_health_check(auto_fix)` repairs them.

One note: CONTRIBUTING says to base PRs on `bcba`, but I don't see that branch in the repo right now,
so I targeted `main`. Happy to retarget if you'd rather.

Fixes #94
