### PR TITLE
feat(sync): materialize portal-served agent definitions across Claude/Codex/Gemini hosts

### DIFF
--- a/src/agentManifestSync.ts
+++ b/src/agentManifestSync.ts
@@ -21,7 +21,7 @@
  */
 
 import { createHash, randomUUID } from "node:crypto";
-import { lstat, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { link, lstat, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -283,15 +283,58 @@ async function currentDigest(path: string): Promise<string | null> {
   }
 }
 
-async function writeAtomic(dir: string, target: string, content: string): Promise<void> {
+/**
+ * Exclusive install: hard-link the temp file into place. Unlike rename(2),
+ * link(2) fails with EEXIST instead of overwriting, so a file that appears
+ * between our existence check and the install cannot be clobbered (TOCTOU).
+ * Returns false when the target already exists.
+ */
+async function installExclusive(dir: string, target: string, content: string): Promise<boolean> {
   const temp = join(dir, `.prism-agent-${randomUUID()}.tmp`);
   await writeFile(temp, content, { mode: 0o600 });
   try {
-    await rename(temp, target);
+    await link(temp, target);
+    return true;
   } catch (error) {
+    if (isErrno(error, "EEXIST")) return false;
+    throw error;
+  } finally {
     await rm(temp, { force: true });
+  }
+}
+
+/**
+ * Claim-then-verify mutation: atomically rename the target out of the root,
+ * re-hash the CLAIMED bytes, and only act when they still match the recorded
+ * digest. A mismatch (someone edited the file inside the check→act window)
+ * restores the file byte-identical and reports a conflict. This closes the
+ * check-then-act race CodeQL flags (js/file-system-race): after the rename we
+ * operate on a path no other writer targets, and the decision digest is
+ * computed from those exact bytes.
+ */
+async function claimVerified(
+  dir: string,
+  target: string,
+  expectedDigest: string,
+): Promise<{ claimed: string } | "gone" | "mismatch"> {
+  const claimPath = join(dir, `.prism-agent-claim-${randomUUID()}.tmp`);
+  try {
+    await rename(target, claimPath);
+  } catch (error) {
+    if (isErrno(error, "ENOENT")) return "gone";
     throw error;
   }
+  const bytes = await readFile(claimPath);
+  if (sha256(bytes) !== expectedDigest) {
+    await rename(claimPath, target); // restore byte-identical
+    return "mismatch";
+  }
+  return { claimed: claimPath };
+}
+
+function isErrno(error: unknown, code: string): boolean {
+  return typeof error === "object" && error !== null && "code" in error
+    && (error as NodeJS.ErrnoException).code === code;
 }
 
 /**
@@ -327,19 +370,22 @@ export async function materializeAgentDefinitions(
   const finalFiles: Record<string, AgentIndexEntry> = {};
 
   // Downgrades first, mirroring the skill engine's ordering: entitlement
-  // removal must not depend on the success of later installs.
+  // removal must not depend on the success of later installs. Deletion is
+  // claim-then-verify: the digest that authorizes the rm is computed from the
+  // bytes AFTER they leave the discovery root, so an edit racing the check
+  // can never be destroyed.
   for (const [name, entry] of Object.entries(owned)) {
     if (incoming.has(name)) continue;
     const target = join(targetDir, entry.file);
-    const digestOnDisk = await currentDigest(target);
-    if (digestOnDisk === null) continue; // already gone
-    if (digestOnDisk === entry.digest) {
-      await rm(target, { force: true });
-      pruned.push(name);
-    } else {
+    const claim = await claimVerified(targetDir, target, entry.digest);
+    if (claim === "gone") continue; // already gone
+    if (claim === "mismatch") {
       // Hand-edited content survives; we merely stop claiming it.
       conflicts.push(name);
+      continue;
     }
+    await rm(claim.claimed, { force: true });
+    pruned.push(name);
   }
 
   for (const [name, rendered] of incoming) {
@@ -347,9 +393,16 @@ export async function materializeAgentDefinitions(
     const renderedDigest = sha256(Buffer.from(rendered.content, "utf8"));
     const digestOnDisk = await currentDigest(target);
     if (digestOnDisk === null) {
-      await writeAtomic(targetDir, target, rendered.content);
-      installed.push(name);
-      finalFiles[name] = { digest: renderedDigest, file: rendered.file };
+      // Exclusive install: a file appearing inside the window makes link()
+      // fail instead of being overwritten; re-judge it as foreign content.
+      if (await installExclusive(targetDir, target, rendered.content)) {
+        installed.push(name);
+        finalFiles[name] = { digest: renderedDigest, file: rendered.file };
+      } else if (await currentDigest(target) === renderedDigest) {
+        finalFiles[name] = { digest: renderedDigest, file: rendered.file };
+      } else {
+        conflicts.push(name);
+      }
       continue;
     }
     const record = owned[name];
@@ -368,9 +421,23 @@ export async function materializeAgentDefinitions(
       finalFiles[name] = { digest: renderedDigest, file: rendered.file };
       continue;
     }
-    await writeAtomic(targetDir, target, rendered.content);
-    updated.push(name);
-    finalFiles[name] = { digest: renderedDigest, file: rendered.file };
+    // Update = claim the old version out (verifying the recorded digest on
+    // the claimed bytes), then exclusively install the new render. A racer
+    // in either window wins the file and we report a conflict instead of
+    // clobbering; the claimed old version is ours and safe to discard.
+    const claim = await claimVerified(targetDir, target, record.digest);
+    if (claim === "mismatch") {
+      conflicts.push(name);
+      continue;
+    }
+    const installedNow = await installExclusive(targetDir, target, rendered.content);
+    if (claim !== "gone") await rm(claim.claimed, { force: true });
+    if (installedNow) {
+      updated.push(name);
+      finalFiles[name] = { digest: renderedDigest, file: rendered.file };
+    } else {
+      conflicts.push(name);
+    }
   }
 
   const nextIndex: AgentIndex = { owner: OWNER, generation: section.generation, files: finalFiles };

--- a/src/agentManifestSync.ts
+++ b/src/agentManifestSync.ts
@@ -1,0 +1,239 @@
+/**
+ * Agent Definition Sync — materializes portal-served agent definitions
+ * (subagent routing policy: model tier, effort cap, tool surface) into
+ * Claude Code's agent root (~/.claude/agents/<name>.md).
+ *
+ * Deliberately separate from skillManifestSync's directory-package engine:
+ * agent definitions are SINGLE FILES, so this module implements file-level
+ * semantics with the same two protective properties the skill engine pins:
+ *
+ *   1. A hand-edited or foreign file is NEVER overwritten or deleted — it is
+ *      reported as a conflict and left byte-identical on disk.
+ *   2. Ownership is provable, not assumed: a file is "ours" only when its
+ *      current content digest matches the digest recorded in the sidecar
+ *      index at the time we last wrote it.
+ *
+ * The server contract (portal /api/v1/prism/skill-manifest) ships agents
+ * under separate `agents` + `agents_generation` fields precisely so that
+ * clients which predate this module ignore them; `generation` remains a
+ * skills-only hash. Do not fold agents into the skills generation on either
+ * side.
+ */
+
+import { createHash, randomUUID } from "node:crypto";
+import { lstat, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const OWNER = "prism-mcp";
+const INDEX = ".prism-agents.json";
+const SAFE_NAME = /^[A-Za-z0-9_-]+$/;
+const SHA256 = /^[a-f0-9]{64}$/i;
+const MAX_AGENTS = 64;
+const MAX_AGENT_BYTES = 256 * 1024;
+
+export interface AgentDefinition {
+  name: string;
+  content: string;
+  digest: string;
+}
+
+export interface AgentSection {
+  agents: AgentDefinition[];
+  generation: string;
+}
+
+export interface AgentSyncOutcome {
+  installed: string[];
+  updated: string[];
+  pruned: string[];
+  conflicts: string[];
+}
+
+interface AgentIndex {
+  owner: typeof OWNER;
+  generation: string;
+  files: Record<string, string>;
+}
+
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+/**
+ * Parse the optional agents section of a skill-manifest payload.
+ * Returns null when the server predates agents (fields absent).
+ * Throws on a malformed section — the caller decides whether that is fatal;
+ * it must never be silently treated as "no agents", because that would turn
+ * contract drift into an invisible prune signal.
+ */
+export function validateAgentSection(payload: unknown): AgentSection | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
+  const value = payload as Record<string, unknown>;
+  if (value.agents === undefined && value.agents_generation === undefined) return null;
+  if (!Array.isArray(value.agents) || typeof value.agents_generation !== "string" ||
+      !SHA256.test(value.agents_generation)) {
+    throw new Error("invalid agent section");
+  }
+  if (value.agents.length > MAX_AGENTS) throw new Error("agent section exceeds bounds");
+  const names = new Set<string>();
+  const agents: AgentDefinition[] = value.agents.map((raw, index) => {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error(`invalid agent at index ${index}`);
+    const agent = raw as Record<string, unknown>;
+    if (typeof agent.name !== "string" || !SAFE_NAME.test(agent.name)) throw new Error(`invalid agent name at index ${index}`);
+    const folded = agent.name.toLocaleLowerCase("en-US");
+    if (names.has(folded)) throw new Error(`duplicate agent name: ${agent.name}`);
+    names.add(folded);
+    if (typeof agent.content !== "string" || !agent.content.trim()) throw new Error(`empty agent content: ${agent.name}`);
+    if (Buffer.byteLength(agent.content, "utf8") > MAX_AGENT_BYTES) throw new Error(`agent definition too large: ${agent.name}`);
+    if (typeof agent.digest !== "string" || !SHA256.test(agent.digest) ||
+        sha256(Buffer.from(agent.content, "utf8")) !== agent.digest.toLowerCase()) {
+      throw new Error(`agent digest mismatch: ${agent.name}`);
+    }
+    return { name: agent.name, content: agent.content, digest: agent.digest.toLowerCase() };
+  });
+  return { agents, generation: value.agents_generation.toLowerCase() };
+}
+
+/**
+ * Claude Code's agent-definition root, mirroring the skill sync's detection
+ * guard: auto-detect only in the production default configuration so tests
+ * and custom-root callers stay isolated.
+ */
+export async function resolveClaudeAgentsDir(options: {
+  homeDir?: string;
+  claudeCodeAgentsDir?: string | false;
+  agentsSkillsDir?: string;
+} = {}): Promise<string | null> {
+  if (options.claudeCodeAgentsDir === false) return null;
+  if (typeof options.claudeCodeAgentsDir === "string") return options.claudeCodeAgentsDir;
+  if (options.agentsSkillsDir !== undefined) return null;
+  const claudeHome = join(options.homeDir ?? homedir(), ".claude");
+  try {
+    const stat = await lstat(claudeHome);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return null;
+  } catch {
+    return null;
+  }
+  return join(claudeHome, "agents");
+}
+
+async function readIndex(path: string): Promise<AgentIndex | null> {
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf8")) as Partial<AgentIndex>;
+    if (parsed?.owner !== OWNER || typeof parsed.files !== "object" || !parsed.files) return null;
+    const files: Record<string, string> = {};
+    for (const [name, digest] of Object.entries(parsed.files)) {
+      if (SAFE_NAME.test(name) && typeof digest === "string" && SHA256.test(digest)) {
+        files[name] = digest.toLowerCase();
+      }
+    }
+    return { owner: OWNER, generation: typeof parsed.generation === "string" ? parsed.generation : "", files };
+  } catch {
+    return null;
+  }
+}
+
+async function currentDigest(path: string): Promise<string | null> {
+  try {
+    const stat = await lstat(path);
+    if (!stat.isFile() || stat.isSymbolicLink()) return null;
+    return sha256(await readFile(path));
+  } catch {
+    return null;
+  }
+}
+
+async function writeAtomic(dir: string, target: string, content: string): Promise<void> {
+  const temp = join(dir, `.prism-agent-${randomUUID()}.tmp`);
+  await writeFile(temp, content, { mode: 0o600 });
+  try {
+    await rename(temp, target);
+  } catch (error) {
+    await rm(temp, { force: true });
+    throw error;
+  }
+}
+
+/**
+ * Apply the agent section to a host agent root. Every write is an atomic
+ * tmp+rename of a single small file; the index commits last, so a crash
+ * mid-run leaves files that the next run re-proves ownership of by digest.
+ */
+export async function materializeAgentDefinitions(
+  section: AgentSection,
+  targetDir: string,
+): Promise<AgentSyncOutcome> {
+  await mkdir(targetDir, { recursive: true, mode: 0o700 });
+  const rootStat = await lstat(targetDir);
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
+    throw new Error("agent root must be a real directory");
+  }
+  const indexPath = join(targetDir, INDEX);
+  const index = await readIndex(indexPath);
+  const owned = index?.files ?? {};
+  const incoming = new Map(section.agents.map((agent) => [agent.name, agent]));
+
+  const installed: string[] = [];
+  const updated: string[] = [];
+  const pruned: string[] = [];
+  const conflicts: string[] = [];
+  const finalFiles: Record<string, string> = {};
+
+  // Downgrades first, mirroring the skill engine's ordering: entitlement
+  // removal must not depend on the success of later installs.
+  for (const [name, recordedDigest] of Object.entries(owned)) {
+    if (incoming.has(name)) continue;
+    const target = join(targetDir, `${name}.md`);
+    const digestOnDisk = await currentDigest(target);
+    if (digestOnDisk === null) continue; // already gone
+    if (digestOnDisk === recordedDigest) {
+      await rm(target, { force: true });
+      pruned.push(name);
+    } else {
+      // Hand-edited content survives; we merely stop claiming it.
+      conflicts.push(name);
+    }
+  }
+
+  for (const agent of section.agents) {
+    const target = join(targetDir, `${agent.name}.md`);
+    const digestOnDisk = await currentDigest(target);
+    if (digestOnDisk === null) {
+      await writeAtomic(targetDir, target, agent.content);
+      installed.push(agent.name);
+      finalFiles[agent.name] = agent.digest;
+      continue;
+    }
+    const pristine = owned[agent.name] !== undefined && digestOnDisk === owned[agent.name];
+    if (!pristine) {
+      if (digestOnDisk === agent.digest) {
+        // Byte-identical foreign file: adopt without writing. Content equality
+        // is the strongest ownership evidence available for a single file.
+        finalFiles[agent.name] = agent.digest;
+      } else {
+        conflicts.push(agent.name);
+      }
+      continue;
+    }
+    if (digestOnDisk === agent.digest) {
+      finalFiles[agent.name] = agent.digest;
+      continue;
+    }
+    await writeAtomic(targetDir, target, agent.content);
+    updated.push(agent.name);
+    finalFiles[agent.name] = agent.digest;
+  }
+
+  const nextIndex: AgentIndex = { owner: OWNER, generation: section.generation, files: finalFiles };
+  const tempIndex = join(targetDir, `${INDEX}.${randomUUID()}.tmp`);
+  await writeFile(tempIndex, `${JSON.stringify(nextIndex, null, 2)}\n`, { mode: 0o600 });
+  await rename(tempIndex, indexPath);
+
+  return {
+    installed: installed.sort(),
+    updated: updated.sort(),
+    pruned: pruned.sort(),
+    conflicts: [...new Set(conflicts)].sort(),
+  };
+}

--- a/src/agentManifestSync.ts
+++ b/src/agentManifestSync.ts
@@ -50,11 +50,109 @@ export interface AgentSyncOutcome {
   conflicts: string[];
 }
 
+/** A host-specific rendering of one canonical agent definition. */
+export interface RenderedAgent {
+  file: string;
+  content: string;
+}
+
+export type AgentRenderer = (agent: AgentDefinition) => RenderedAgent | null;
+
+interface AgentIndexEntry {
+  digest: string;
+  file: string;
+}
+
 interface AgentIndex {
   owner: typeof OWNER;
   generation: string;
-  files: Record<string, string>;
+  files: Record<string, AgentIndexEntry>;
 }
+
+/** Parsed canonical AGENT.md: Claude-style frontmatter plus prompt body. */
+export interface ParsedAgentDefinition {
+  fields: Record<string, string>;
+  body: string;
+}
+
+export function parseAgentDefinition(content: string): ParsedAgentDefinition {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n?/);
+  if (!match) return { fields: {}, body: content };
+  const fields: Record<string, string> = {};
+  for (const line of match[1].split("\n")) {
+    const entry = line.match(/^([A-Za-z_-]+):\s*(.*)$/);
+    if (entry) fields[entry[1]] = entry[2].trim();
+  }
+  return { fields, body: content.slice(match[0].length) };
+}
+
+// ─── Host renderers ──────────────────────────────────────────
+//
+// The canonical format is Claude Code's agent markdown; other hosts receive a
+// translation of the universally-expressible subset. Model tier is
+// DELIBERATELY not translated: model namespaces are host-specific and rotate
+// (gpt-5.6-* today), so foreign hosts keep their own configured defaults
+// (codex: default_subagent_model) and only the proven effort/tool-surface
+// levers travel.
+
+/** Claude Code: the canonical content verbatim. */
+export const renderClaudeAgent: AgentRenderer = (agent) => ({
+  file: `${agent.name}.md`,
+  content: agent.content,
+});
+
+const CODEX_EFFORT: Record<string, string> = {
+  low: "low", medium: "medium", high: "high", xhigh: "high", max: "high",
+};
+
+function tomlString(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n")}"`;
+}
+
+function tomlMultiline(value: string): string {
+  // Escaping every backslash and quote keeps any body (including """ runs)
+  // valid inside a multiline basic string while preserving literal newlines.
+  return `"""\n${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"""`;
+}
+
+/**
+ * Codex: ~/.codex/agents/<name>.toml. Keys verified against codex 0.146.0:
+ * name, description, developer_instructions, model_reasoning_effort,
+ * sandbox_mode. A Bash-bearing tool surface implies the agent must execute
+ * reproductions, so it gets workspace-write; otherwise read-only.
+ */
+export const renderCodexAgent: AgentRenderer = (agent) => {
+  const { fields, body } = parseAgentDefinition(agent.content);
+  const effort = CODEX_EFFORT[fields.effort ?? ""];
+  const tools = (fields.tools ?? "").split(",").map((tool) => tool.trim());
+  const sandbox = tools.includes("Bash") ? "workspace-write" : "read-only";
+  const lines = [
+    `name = ${tomlString(agent.name)}`,
+    `description = ${tomlString(fields.description ?? agent.name)}`,
+    ...(effort ? [`model_reasoning_effort = ${tomlString(effort)}`] : []),
+    `sandbox_mode = ${tomlString(sandbox)}`,
+    `developer_instructions = ${tomlMultiline(body)}`,
+  ];
+  return { file: `${agent.name}.toml`, content: `${lines.join("\n")}\n` };
+};
+
+/**
+ * Gemini CLI: ~/.gemini/agents/<name>.md (verified loadAgentsFromDirectory:
+ * .md files, "_"-prefixed skipped). Frontmatter is reduced to the fields
+ * gemini understands; Claude-specific keys (tools/model/effort) are dropped
+ * rather than risked against a stricter parser. Coexists with the
+ * prism-connect agent policy that owns ~/.gemini/settings.json overrides.
+ */
+export const renderGeminiAgent: AgentRenderer = (agent) => {
+  const { fields, body } = parseAgentDefinition(agent.content);
+  const frontmatter = [
+    "---",
+    `name: ${agent.name}`,
+    `description: ${fields.description ?? agent.name}`,
+    "---",
+  ].join("\n");
+  return { file: `${agent.name}.md`, content: `${frontmatter}\n\n${body}` };
+};
 
 function sha256(value: string | Buffer): string {
   return createHash("sha256").update(value).digest("hex");
@@ -118,14 +216,55 @@ export async function resolveClaudeAgentsDir(options: {
   return join(claudeHome, "agents");
 }
 
+async function detectHostAgentsDir(hostHome: string): Promise<string | null> {
+  try {
+    const stat = await lstat(hostHome);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return null;
+  } catch {
+    return null;
+  }
+  return join(hostHome, "agents");
+}
+
+/** Codex agent root (~/.codex/agents or $CODEX_HOME/agents), same guards. */
+export async function resolveCodexAgentsDir(options: {
+  homeDir?: string;
+  codexAgentsDir?: string | false;
+  agentsSkillsDir?: string;
+  env?: NodeJS.ProcessEnv;
+} = {}): Promise<string | null> {
+  if (options.codexAgentsDir === false) return null;
+  if (typeof options.codexAgentsDir === "string") return options.codexAgentsDir;
+  if (options.agentsSkillsDir !== undefined) return null;
+  const configured = (options.env ?? process.env).CODEX_HOME?.trim();
+  const codexHome = configured || join(options.homeDir ?? homedir(), ".codex");
+  return detectHostAgentsDir(codexHome);
+}
+
+/** Gemini CLI agent root (~/.gemini/agents), same guards. */
+export async function resolveGeminiAgentsDir(options: {
+  homeDir?: string;
+  geminiAgentsDir?: string | false;
+  agentsSkillsDir?: string;
+} = {}): Promise<string | null> {
+  if (options.geminiAgentsDir === false) return null;
+  if (typeof options.geminiAgentsDir === "string") return options.geminiAgentsDir;
+  if (options.agentsSkillsDir !== undefined) return null;
+  return detectHostAgentsDir(join(options.homeDir ?? homedir(), ".gemini"));
+}
+
+const SAFE_FILE = /^[A-Za-z0-9_-]+\.(md|toml)$/;
+
 async function readIndex(path: string): Promise<AgentIndex | null> {
   try {
     const parsed = JSON.parse(await readFile(path, "utf8")) as Partial<AgentIndex>;
     if (parsed?.owner !== OWNER || typeof parsed.files !== "object" || !parsed.files) return null;
-    const files: Record<string, string> = {};
-    for (const [name, digest] of Object.entries(parsed.files)) {
-      if (SAFE_NAME.test(name) && typeof digest === "string" && SHA256.test(digest)) {
-        files[name] = digest.toLowerCase();
+    const files: Record<string, AgentIndexEntry> = {};
+    for (const [name, entry] of Object.entries(parsed.files)) {
+      if (!SAFE_NAME.test(name) || !entry || typeof entry !== "object") continue;
+      const { digest, file } = entry as Partial<AgentIndexEntry>;
+      if (typeof digest === "string" && SHA256.test(digest) && typeof file === "string" && SAFE_FILE.test(file)) {
+        files[name] = { digest: digest.toLowerCase(), file };
       }
     }
     return { owner: OWNER, generation: typeof parsed.generation === "string" ? parsed.generation : "", files };
@@ -163,6 +302,7 @@ async function writeAtomic(dir: string, target: string, content: string): Promis
 export async function materializeAgentDefinitions(
   section: AgentSection,
   targetDir: string,
+  render: AgentRenderer = renderClaudeAgent,
 ): Promise<AgentSyncOutcome> {
   await mkdir(targetDir, { recursive: true, mode: 0o700 });
   const rootStat = await lstat(targetDir);
@@ -172,22 +312,28 @@ export async function materializeAgentDefinitions(
   const indexPath = join(targetDir, INDEX);
   const index = await readIndex(indexPath);
   const owned = index?.files ?? {};
-  const incoming = new Map(section.agents.map((agent) => [agent.name, agent]));
+  const incoming = new Map<string, RenderedAgent>();
+  for (const agent of section.agents) {
+    const rendered = render(agent);
+    if (rendered === null) continue;
+    if (!SAFE_FILE.test(rendered.file)) throw new Error(`unsafe rendered agent file: ${rendered.file}`);
+    incoming.set(agent.name, rendered);
+  }
 
   const installed: string[] = [];
   const updated: string[] = [];
   const pruned: string[] = [];
   const conflicts: string[] = [];
-  const finalFiles: Record<string, string> = {};
+  const finalFiles: Record<string, AgentIndexEntry> = {};
 
   // Downgrades first, mirroring the skill engine's ordering: entitlement
   // removal must not depend on the success of later installs.
-  for (const [name, recordedDigest] of Object.entries(owned)) {
+  for (const [name, entry] of Object.entries(owned)) {
     if (incoming.has(name)) continue;
-    const target = join(targetDir, `${name}.md`);
+    const target = join(targetDir, entry.file);
     const digestOnDisk = await currentDigest(target);
     if (digestOnDisk === null) continue; // already gone
-    if (digestOnDisk === recordedDigest) {
+    if (digestOnDisk === entry.digest) {
       await rm(target, { force: true });
       pruned.push(name);
     } else {
@@ -196,33 +342,35 @@ export async function materializeAgentDefinitions(
     }
   }
 
-  for (const agent of section.agents) {
-    const target = join(targetDir, `${agent.name}.md`);
+  for (const [name, rendered] of incoming) {
+    const target = join(targetDir, rendered.file);
+    const renderedDigest = sha256(Buffer.from(rendered.content, "utf8"));
     const digestOnDisk = await currentDigest(target);
     if (digestOnDisk === null) {
-      await writeAtomic(targetDir, target, agent.content);
-      installed.push(agent.name);
-      finalFiles[agent.name] = agent.digest;
+      await writeAtomic(targetDir, target, rendered.content);
+      installed.push(name);
+      finalFiles[name] = { digest: renderedDigest, file: rendered.file };
       continue;
     }
-    const pristine = owned[agent.name] !== undefined && digestOnDisk === owned[agent.name];
+    const record = owned[name];
+    const pristine = record !== undefined && record.file === rendered.file && digestOnDisk === record.digest;
     if (!pristine) {
-      if (digestOnDisk === agent.digest) {
+      if (digestOnDisk === renderedDigest) {
         // Byte-identical foreign file: adopt without writing. Content equality
         // is the strongest ownership evidence available for a single file.
-        finalFiles[agent.name] = agent.digest;
+        finalFiles[name] = { digest: renderedDigest, file: rendered.file };
       } else {
-        conflicts.push(agent.name);
+        conflicts.push(name);
       }
       continue;
     }
-    if (digestOnDisk === agent.digest) {
-      finalFiles[agent.name] = agent.digest;
+    if (digestOnDisk === renderedDigest) {
+      finalFiles[name] = { digest: renderedDigest, file: rendered.file };
       continue;
     }
-    await writeAtomic(targetDir, target, agent.content);
-    updated.push(agent.name);
-    finalFiles[agent.name] = agent.digest;
+    await writeAtomic(targetDir, target, rendered.content);
+    updated.push(name);
+    finalFiles[name] = { digest: renderedDigest, file: rendered.file };
   }
 
   const nextIndex: AgentIndex = { owner: OWNER, generation: section.generation, files: finalFiles };

--- a/src/skillManifestSync.ts
+++ b/src/skillManifestSync.ts
@@ -9,7 +9,8 @@ import {
   applyManagedSkillManifest, getSetting, refreshConfigStorageCache,
 } from "./storage/configStorage.js";
 import {
-  materializeAgentDefinitions, resolveClaudeAgentsDir, validateAgentSection,
+  materializeAgentDefinitions, renderClaudeAgent, renderCodexAgent, renderGeminiAgent,
+  resolveClaudeAgentsDir, resolveCodexAgentsDir, resolveGeminiAgentsDir, validateAgentSection,
   type AgentSection,
 } from "./agentManifestSync.js";
 import { FREE_NATIVE_SKILL_NAMES, REQUIRED_NATIVE_SKILL_NAMES } from "./tools/skillRouting.js";
@@ -124,6 +125,10 @@ export interface SkillSyncOptions {
    * production-default guard as the skill mirrors.
    */
   claudeCodeAgentsDir?: string | false;
+  /** Codex agent root (~/.codex/agents, TOML renders). Same semantics. */
+  codexAgentsDir?: string | false;
+  /** Gemini CLI agent root (~/.gemini/agents, reduced markdown). Same semantics. */
+  geminiAgentsDir?: string | false;
   fetchImpl?: typeof fetch;
   getJwt?: () => Promise<string | null>;
   invalidateJwt?: () => void;
@@ -946,21 +951,26 @@ export async function synchronizeSkillManifest(options: SkillSyncOptions = {}): 
     }
     const native = mergeNativeResults(nativeResults);
     // Agent definitions are additive: they piggyback on the manifest with
-    // their own generation, and their outcome reports under an `agent:`
-    // prefix. A failure here never rolls back or degrades skill state — it
-    // surfaces as a conflict instead.
+    // their own generation, and each host's outcome reports under its own
+    // prefix. A failure on one host never rolls back skill state or the
+    // other hosts — it surfaces as a conflict instead.
     if (manifest.agentSection) {
-      const agentsDir = await resolveClaudeAgentsDir(options);
-      if (agentsDir) {
+      const hostTargets = [
+        { prefix: "agent", dir: await resolveClaudeAgentsDir(options), render: renderClaudeAgent },
+        { prefix: "agent-codex", dir: await resolveCodexAgentsDir(options), render: renderCodexAgent },
+        { prefix: "agent-gemini", dir: await resolveGeminiAgentsDir(options), render: renderGeminiAgent },
+      ];
+      for (const host of hostTargets) {
+        if (!host.dir) continue;
         try {
-          const outcome = await materializeAgentDefinitions(manifest.agentSection, agentsDir);
-          native.installed.push(...outcome.installed.map((name) => `agent:${name}`));
-          native.updated.push(...outcome.updated.map((name) => `agent:${name}`));
-          native.pruned.push(...outcome.pruned.map((name) => `agent:${name}`));
-          native.conflicts.push(...outcome.conflicts.map((name) => `agent:${name}`));
+          const outcome = await materializeAgentDefinitions(manifest.agentSection, host.dir, host.render);
+          native.installed.push(...outcome.installed.map((name) => `${host.prefix}:${name}`));
+          native.updated.push(...outcome.updated.map((name) => `${host.prefix}:${name}`));
+          native.pruned.push(...outcome.pruned.map((name) => `${host.prefix}:${name}`));
+          native.conflicts.push(...outcome.conflicts.map((name) => `${host.prefix}:${name}`));
         } catch (error) {
-          console.error(`[Prism Skill Sync] agent materialization failed: ${error instanceof Error ? error.message : String(error)}`);
-          native.conflicts.push("agent:sync-failed");
+          console.error(`[Prism Skill Sync] ${host.prefix} materialization failed: ${error instanceof Error ? error.message : String(error)}`);
+          native.conflicts.push(`${host.prefix}:sync-failed`);
         }
       }
     }

--- a/src/skillManifestSync.ts
+++ b/src/skillManifestSync.ts
@@ -8,6 +8,10 @@ import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import {
   applyManagedSkillManifest, getSetting, refreshConfigStorageCache,
 } from "./storage/configStorage.js";
+import {
+  materializeAgentDefinitions, resolveClaudeAgentsDir, validateAgentSection,
+  type AgentSection,
+} from "./agentManifestSync.js";
 import { FREE_NATIVE_SKILL_NAMES, REQUIRED_NATIVE_SKILL_NAMES } from "./tools/skillRouting.js";
 import { getSynaluxJwt, invalidateSynaluxJwt } from "./utils/synaluxJwt.js";
 
@@ -57,6 +61,12 @@ export interface SkillManifest {
   tier: "free" | "standard" | "advanced" | "enterprise";
   routing_version: number;
   skills: ManifestSkill[];
+  /**
+   * Optional agent-definition section (portal `agents` + `agents_generation`
+   * fields). Absent on servers that predate agents. Deliberately OUTSIDE the
+   * skills `generation` hash — see agentManifestSync.ts for the contract.
+   */
+  agentSection?: AgentSection | null;
 }
 
 export interface SkillSyncResult {
@@ -108,6 +118,12 @@ export interface SkillSyncOptions {
    * ~/.agents/skills root, so tests and callers with custom roots stay isolated.
    */
   cursorSkillsDir?: string | false;
+  /**
+   * Claude Code's agent-definition root (~/.claude/agents). `false` disables
+   * agent materialization. When omitted, auto-detected under the same
+   * production-default guard as the skill mirrors.
+   */
+  claudeCodeAgentsDir?: string | false;
   fetchImpl?: typeof fetch;
   getJwt?: () => Promise<string | null>;
   invalidateJwt?: () => void;
@@ -816,6 +832,10 @@ async function fetchManifest(options: SkillSyncOptions): Promise<SkillManifest> 
   if (!headers.Authorization && manifest.tier !== "free") {
     throw new Error("unauthenticated skill manifest must be free tier");
   }
+  // Agents ride the same response under separate fields. A malformed section
+  // is contract drift and must fail the fetch loudly — treating it as "no
+  // agents" would convert server corruption into a silent prune signal.
+  manifest.agentSection = validateAgentSection(payload);
   return manifest;
 }
 
@@ -925,6 +945,25 @@ export async function synchronizeSkillManifest(options: SkillSyncOptions = {}): 
       nativeResults.push(await materializeNative(manifest, nativeSkillsDir, options));
     }
     const native = mergeNativeResults(nativeResults);
+    // Agent definitions are additive: they piggyback on the manifest with
+    // their own generation, and their outcome reports under an `agent:`
+    // prefix. A failure here never rolls back or degrades skill state — it
+    // surfaces as a conflict instead.
+    if (manifest.agentSection) {
+      const agentsDir = await resolveClaudeAgentsDir(options);
+      if (agentsDir) {
+        try {
+          const outcome = await materializeAgentDefinitions(manifest.agentSection, agentsDir);
+          native.installed.push(...outcome.installed.map((name) => `agent:${name}`));
+          native.updated.push(...outcome.updated.map((name) => `agent:${name}`));
+          native.pruned.push(...outcome.pruned.map((name) => `agent:${name}`));
+          native.conflicts.push(...outcome.conflicts.map((name) => `agent:${name}`));
+        } catch (error) {
+          console.error(`[Prism Skill Sync] agent materialization failed: ${error instanceof Error ? error.message : String(error)}`);
+          native.conflicts.push("agent:sync-failed");
+        }
+      }
+    }
     const status = native.installed.length || native.updated.length || native.pruned.length ? "applied" : "unchanged";
     return {
       status,

--- a/tests/agent-manifest-sync.test.ts
+++ b/tests/agent-manifest-sync.test.ts
@@ -3,9 +3,15 @@ import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { parse as parseToml } from "smol-toml";
 import {
   materializeAgentDefinitions,
+  parseAgentDefinition,
+  renderCodexAgent,
+  renderGeminiAgent,
   resolveClaudeAgentsDir,
+  resolveCodexAgentsDir,
+  resolveGeminiAgentsDir,
   validateAgentSection,
   type AgentSection,
 } from "../src/agentManifestSync.js";
@@ -90,7 +96,7 @@ describe("materializeAgentDefinitions", () => {
     expect(await readFile(join(dir, "fast-scanner.md"), "utf8")).toBe(scanner.content);
     const index = JSON.parse(await readFile(join(dir, ".prism-agents.json"), "utf8"));
     expect(index.owner).toBe("prism-mcp");
-    expect(index.files["fast-scanner"]).toBe(scanner.digest);
+    expect(index.files["fast-scanner"]).toEqual({ digest: scanner.digest, file: "fast-scanner.md" });
   });
 
   it("is idempotent: an unchanged section performs no writes", async () => {
@@ -140,7 +146,7 @@ describe("materializeAgentDefinitions", () => {
     const adopt = await materializeAgentDefinitions(section(incoming), dir);
     expect(adopt).toEqual({ installed: [], updated: [], pruned: [], conflicts: [] });
     const index = JSON.parse(await readFile(join(dir, ".prism-agents.json"), "utf8"));
-    expect(index.files["fast-scanner"]).toBe(incoming.digest);
+    expect(index.files["fast-scanner"]).toEqual({ digest: incoming.digest, file: "fast-scanner.md" });
   });
 
   it("prunes a pristine owned file on entitlement loss but preserves a hand-edited one", async () => {
@@ -155,6 +161,103 @@ describe("materializeAgentDefinitions", () => {
     const remaining = await readdir(dir);
     expect(remaining).not.toContain("fast-scanner.md");
     expect(await readFile(join(dir, "deep-verifier.md"), "utf8")).toBe("hand tuned\n");
+  });
+});
+
+describe("host renderers", () => {
+  const canonical = [
+    "---",
+    "name: fast-scanner",
+    "description: Cheap agent for bounded mechanical work.",
+    "tools: Read, Grep, Glob",
+    "model: haiku",
+    "effort: low",
+    "---",
+    "",
+    "You are a fast scanner. Return raw data.",
+    "",
+  ].join("\n");
+
+  it("parses canonical frontmatter and body", () => {
+    const { fields, body } = parseAgentDefinition(canonical);
+    expect(fields).toMatchObject({ name: "fast-scanner", effort: "low", model: "haiku" });
+    expect(body).toContain("You are a fast scanner.");
+    expect(parseAgentDefinition("no frontmatter")).toEqual({ fields: {}, body: "no frontmatter" });
+  });
+
+  it("renders valid codex TOML with mapped effort and tool-derived sandbox", () => {
+    const scanner = { name: "fast-scanner", content: canonical, digest: digest(canonical) };
+    const rendered = renderCodexAgent(scanner)!;
+    expect(rendered.file).toBe("fast-scanner.toml");
+    const parsed = parseToml(rendered.content) as Record<string, unknown>;
+    expect(parsed).toMatchObject({
+      name: "fast-scanner",
+      description: "Cheap agent for bounded mechanical work.",
+      model_reasoning_effort: "low",
+      sandbox_mode: "read-only",
+    });
+    expect(parsed.developer_instructions).toContain("You are a fast scanner.");
+    // Model tier deliberately does NOT travel to foreign hosts.
+    expect(rendered.content).not.toContain("haiku");
+
+    const verifierContent = canonical
+      .replace("tools: Read, Grep, Glob", "tools: Read, Grep, Glob, Bash")
+      .replace("effort: low", "effort: xhigh");
+    const verifier = { name: "fast-scanner", content: verifierContent, digest: digest(verifierContent) };
+    const parsedVerifier = parseToml(renderCodexAgent(verifier)!.content) as Record<string, unknown>;
+    expect(parsedVerifier.model_reasoning_effort).toBe("high"); // xhigh maps into codex vocabulary
+    expect(parsedVerifier.sandbox_mode).toBe("workspace-write"); // Bash implies execution
+  });
+
+  it("survives TOML-hostile bodies: quotes, backslashes, triple-quote runs", () => {
+    const hostile = `---\nname: hostile\ndescription: has "quotes" and \\ paths\neffort: low\ntools: Read\n---\nsay """hi""" C:\\temp\\x and "quoted"\n`;
+    const agent = { name: "hostile", content: hostile, digest: digest(hostile) };
+    const parsed = parseToml(renderCodexAgent(agent)!.content) as Record<string, unknown>;
+    expect(parsed.description).toBe('has "quotes" and \\ paths');
+    expect(parsed.developer_instructions).toContain('say """hi""" C:\\temp\\x and "quoted"');
+  });
+
+  it("renders gemini markdown with reduced frontmatter and preserved body", () => {
+    const scanner = { name: "fast-scanner", content: canonical, digest: digest(canonical) };
+    const rendered = renderGeminiAgent(scanner)!;
+    expect(rendered.file).toBe("fast-scanner.md");
+    const { fields, body } = parseAgentDefinition(rendered.content);
+    expect(fields).toEqual({ name: "fast-scanner", description: "Cheap agent for bounded mechanical work." });
+    expect(fields.tools).toBeUndefined();
+    expect(fields.effort).toBeUndefined();
+    expect(body).toContain("You are a fast scanner.");
+  });
+
+  it("materializes and prunes renderer-shaped files through the same ownership engine", async () => {
+    const dir = join(await tempRoot(), "codex-agents");
+    const scanner = definition("fast-scanner");
+    const first = await materializeAgentDefinitions(section(scanner), dir, renderCodexAgent);
+    expect(first.installed).toEqual(["fast-scanner"]);
+    expect(parseToml(await readFile(join(dir, "fast-scanner.toml"), "utf8"))).toMatchObject({ name: "fast-scanner" });
+    const gone = await materializeAgentDefinitions(section(), dir, renderCodexAgent);
+    expect(gone.pruned).toEqual(["fast-scanner"]);
+    expect((await readdir(dir)).filter((file) => file.endsWith(".toml"))).toEqual([]);
+  });
+});
+
+describe("host root resolvers", () => {
+  it("detects codex (incl. CODEX_HOME) and gemini homes under the production-default guard", async () => {
+    const home = await tempRoot();
+    const { mkdir } = await import("node:fs/promises");
+    expect(await resolveCodexAgentsDir({ homeDir: home, env: {} })).toBeNull();
+    expect(await resolveGeminiAgentsDir({ homeDir: home })).toBeNull();
+    await mkdir(join(home, ".codex"));
+    await mkdir(join(home, ".gemini"));
+    expect(await resolveCodexAgentsDir({ homeDir: home, env: {} })).toBe(join(home, ".codex", "agents"));
+    expect(await resolveGeminiAgentsDir({ homeDir: home })).toBe(join(home, ".gemini", "agents"));
+    const custom = join(home, "custom-codex");
+    await mkdir(custom);
+    expect(await resolveCodexAgentsDir({ homeDir: home, env: { CODEX_HOME: custom } })).toBe(join(custom, "agents"));
+    // Custom skill roots (test isolation) suppress auto-detection.
+    expect(await resolveCodexAgentsDir({ homeDir: home, env: {}, agentsSkillsDir: "/custom" })).toBeNull();
+    expect(await resolveGeminiAgentsDir({ homeDir: home, agentsSkillsDir: "/custom" })).toBeNull();
+    expect(await resolveCodexAgentsDir({ homeDir: home, env: {}, codexAgentsDir: false })).toBeNull();
+    expect(await resolveGeminiAgentsDir({ homeDir: home, geminiAgentsDir: false })).toBeNull();
   });
 });
 
@@ -177,11 +280,13 @@ describe("synchronizeSkillManifest agent wiring", () => {
     };
   }
 
-  it("materializes served agents alongside skills and reports them with an agent: prefix", async () => {
+  it("materializes served agents into every detected host root with per-host prefixes", async () => {
     _resetSkillManifestSyncForTest();
     const fixture = await tempRoot();
     const agentsSkillsDir = join(fixture, "skills");
     const claudeCodeAgentsDir = join(fixture, ".claude", "agents");
+    const codexAgentsDir = join(fixture, ".codex", "agents");
+    const geminiAgentsDir = join(fixture, ".gemini", "agents");
     const skills = [...REQUIRED_NATIVE_SKILL_NAMES].map(skillEntry)
       .sort((a, b) => a.metadata.priority - b.metadata.priority || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
     const snapshot: SkillManifest = {
@@ -201,6 +306,8 @@ describe("synchronizeSkillManifest agent wiring", () => {
       claudeCodeSkillsDir: false,
       cursorSkillsDir: false,
       claudeCodeAgentsDir,
+      codexAgentsDir,
+      geminiAgentsDir,
       applyManifest: vi.fn(async () => undefined),
       fetchImpl: vi.fn(() => jsonResponse(payload)) as unknown as typeof fetch,
       configuredCredential: true,
@@ -208,8 +315,17 @@ describe("synchronizeSkillManifest agent wiring", () => {
     });
 
     expect(result.status).toBe("applied");
-    expect(result.installed).toContain("agent:fast-scanner");
+    expect(result.installed).toEqual(expect.arrayContaining([
+      "agent:fast-scanner", "agent-codex:fast-scanner", "agent-gemini:fast-scanner",
+    ]));
+    // Claude receives the canonical bytes; codex a TOML render; gemini a
+    // reduced-frontmatter markdown render.
     expect(await readFile(join(claudeCodeAgentsDir, "fast-scanner.md"), "utf8")).toBe(scanner.content);
+    const codexParsed = parseToml(await readFile(join(codexAgentsDir, "fast-scanner.toml"), "utf8")) as Record<string, unknown>;
+    expect(codexParsed.name).toBe("fast-scanner");
+    expect(codexParsed.model_reasoning_effort).toBe("low");
+    const geminiParsed = parseAgentDefinition(await readFile(join(geminiAgentsDir, "fast-scanner.md"), "utf8"));
+    expect(geminiParsed.fields).toEqual({ name: "fast-scanner", description: expect.any(String) });
 
     // FROZEN CONTRACT: agents ride outside the skills generation. A payload
     // whose agents perturbed `generation` would have failed validation above,

--- a/tests/agent-manifest-sync.test.ts
+++ b/tests/agent-manifest-sync.test.ts
@@ -1,0 +1,250 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  materializeAgentDefinitions,
+  resolveClaudeAgentsDir,
+  validateAgentSection,
+  type AgentSection,
+} from "../src/agentManifestSync.js";
+import {
+  _resetSkillManifestSyncForTest,
+  computeSkillManifestGeneration,
+  synchronizeSkillManifest,
+  type SkillManifest,
+} from "../src/skillManifestSync.js";
+import { FREE_NATIVE_SKILL_NAMES, REQUIRED_NATIVE_SKILL_NAMES } from "../src/tools/skillRouting.js";
+
+const roots: string[] = [];
+const digest = (value: string | Buffer) => createHash("sha256").update(value).digest("hex");
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "prism-agent-sync-"));
+  roots.push(root);
+  return root;
+}
+
+function definition(name: string, body = `# ${name} body\n`) {
+  const content = `---\nname: ${name}\neffort: low\n---\n${body}`;
+  return { name, content, digest: digest(content) };
+}
+
+function section(...agents: ReturnType<typeof definition>[]): AgentSection {
+  return { agents, generation: digest(JSON.stringify(agents.map((agent) => agent.digest))) };
+}
+
+afterEach(async () => {
+  while (roots.length > 0) await rm(roots.pop()!, { recursive: true, force: true });
+});
+
+describe("validateAgentSection", () => {
+  it("returns null for a payload that predates agents", () => {
+    expect(validateAgentSection({ schema_version: 1, skills: [] })).toBeNull();
+  });
+
+  it("parses a valid section and normalizes digest case", () => {
+    const agent = definition("fast-scanner");
+    const parsed = validateAgentSection({
+      agents: [{ ...agent, digest: agent.digest.toUpperCase() }],
+      agents_generation: digest("gen"),
+    });
+    expect(parsed?.agents).toEqual([agent]);
+  });
+
+  it("throws on drift instead of treating it as an empty section", () => {
+    const agent = definition("fast-scanner");
+    expect(() => validateAgentSection({ agents: [agent], agents_generation: "not-a-hash" }))
+      .toThrow(/invalid agent section/);
+    expect(() => validateAgentSection({ agents: [{ ...agent, digest: digest("other") }], agents_generation: digest("gen") }))
+      .toThrow(/digest mismatch/);
+    expect(() => validateAgentSection({ agents: [{ ...agent, name: "../escape" }], agents_generation: digest("gen") }))
+      .toThrow(/invalid agent name/);
+    expect(() => validateAgentSection({
+      agents: [agent, { ...definition("FAST-scanner") }], agents_generation: digest("gen"),
+    })).toThrow(/duplicate agent name/);
+  });
+});
+
+describe("resolveClaudeAgentsDir", () => {
+  it("auto-detects only when ~/.claude exists and no custom root is configured", async () => {
+    const home = await tempRoot();
+    expect(await resolveClaudeAgentsDir({ homeDir: home })).toBeNull();
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(join(home, ".claude"));
+    expect(await resolveClaudeAgentsDir({ homeDir: home })).toBe(join(home, ".claude", "agents"));
+    expect(await resolveClaudeAgentsDir({ homeDir: home, agentsSkillsDir: "/custom" })).toBeNull();
+    expect(await resolveClaudeAgentsDir({ homeDir: home, claudeCodeAgentsDir: false })).toBeNull();
+    expect(await resolveClaudeAgentsDir({ homeDir: home, claudeCodeAgentsDir: "/explicit" })).toBe("/explicit");
+  });
+});
+
+describe("materializeAgentDefinitions", () => {
+  it("installs into an empty root and commits an owned index", async () => {
+    const root = await tempRoot();
+    const dir = join(root, "agents");
+    const scanner = definition("fast-scanner");
+    const outcome = await materializeAgentDefinitions(section(scanner), dir);
+    expect(outcome).toEqual({ installed: ["fast-scanner"], updated: [], pruned: [], conflicts: [] });
+    expect(await readFile(join(dir, "fast-scanner.md"), "utf8")).toBe(scanner.content);
+    const index = JSON.parse(await readFile(join(dir, ".prism-agents.json"), "utf8"));
+    expect(index.owner).toBe("prism-mcp");
+    expect(index.files["fast-scanner"]).toBe(scanner.digest);
+  });
+
+  it("is idempotent: an unchanged section performs no writes", async () => {
+    const dir = join(await tempRoot(), "agents");
+    const scanner = definition("fast-scanner");
+    await materializeAgentDefinitions(section(scanner), dir);
+    const outcome = await materializeAgentDefinitions(section(scanner), dir);
+    expect(outcome).toEqual({ installed: [], updated: [], pruned: [], conflicts: [] });
+  });
+
+  it("updates a pristine owned file when the definition changes", async () => {
+    const dir = join(await tempRoot(), "agents");
+    await materializeAgentDefinitions(section(definition("fast-scanner", "v1\n")), dir);
+    const v2 = definition("fast-scanner", "v2\n");
+    const outcome = await materializeAgentDefinitions(section(v2), dir);
+    expect(outcome.updated).toEqual(["fast-scanner"]);
+    expect(await readFile(join(dir, "fast-scanner.md"), "utf8")).toBe(v2.content);
+  });
+
+  it("NEVER overwrites a hand-edited managed file — conflict, bytes preserved", async () => {
+    const dir = join(await tempRoot(), "agents");
+    await materializeAgentDefinitions(section(definition("deep-verifier", "shipped\n")), dir);
+    const handEdit = "---\nname: deep-verifier\neffort: max\n---\nlocal tuning\n";
+    await writeFile(join(dir, "deep-verifier.md"), handEdit);
+    const outcome = await materializeAgentDefinitions(section(definition("deep-verifier", "shipped v2\n")), dir);
+    expect(outcome.conflicts).toEqual(["deep-verifier"]);
+    expect(outcome.updated).toEqual([]);
+    expect(await readFile(join(dir, "deep-verifier.md"), "utf8")).toBe(handEdit);
+    // Ownership is dropped: the index no longer claims the edited file.
+    const index = JSON.parse(await readFile(join(dir, ".prism-agents.json"), "utf8"));
+    expect(index.files["deep-verifier"]).toBeUndefined();
+  });
+
+  it("never touches a foreign file it did not write, unless byte-identical", async () => {
+    const dir = join(await tempRoot(), "agents");
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(dir, { recursive: true });
+    const foreign = "user-authored agent\n";
+    await writeFile(join(dir, "fast-scanner.md"), foreign);
+    const incoming = definition("fast-scanner");
+    const outcome = await materializeAgentDefinitions(section(incoming), dir);
+    expect(outcome.conflicts).toEqual(["fast-scanner"]);
+    expect(await readFile(join(dir, "fast-scanner.md"), "utf8")).toBe(foreign);
+
+    // Byte-identical foreign content is adopted without a write.
+    await writeFile(join(dir, "fast-scanner.md"), incoming.content);
+    const adopt = await materializeAgentDefinitions(section(incoming), dir);
+    expect(adopt).toEqual({ installed: [], updated: [], pruned: [], conflicts: [] });
+    const index = JSON.parse(await readFile(join(dir, ".prism-agents.json"), "utf8"));
+    expect(index.files["fast-scanner"]).toBe(incoming.digest);
+  });
+
+  it("prunes a pristine owned file on entitlement loss but preserves a hand-edited one", async () => {
+    const dir = join(await tempRoot(), "agents");
+    const scanner = definition("fast-scanner");
+    const verifier = definition("deep-verifier");
+    await materializeAgentDefinitions(section(scanner, verifier), dir);
+    await writeFile(join(dir, "deep-verifier.md"), "hand tuned\n");
+    const outcome = await materializeAgentDefinitions(section(), dir);
+    expect(outcome.pruned).toEqual(["fast-scanner"]);
+    expect(outcome.conflicts).toEqual(["deep-verifier"]);
+    const remaining = await readdir(dir);
+    expect(remaining).not.toContain("fast-scanner.md");
+    expect(await readFile(join(dir, "deep-verifier.md"), "utf8")).toBe("hand tuned\n");
+  });
+});
+
+describe("synchronizeSkillManifest agent wiring", () => {
+  function jsonResponse(value: unknown, status = 200): Promise<Response> {
+    return Promise.resolve(new Response(JSON.stringify(value), { status, headers: { "content-type": "application/json" } }));
+  }
+
+  function skillEntry(name: string) {
+    const content = `---\nname: ${name}\n---\n# ${name}\n`;
+    const priority = REQUIRED_NATIVE_SKILL_NAMES.indexOf(name as typeof REQUIRED_NATIVE_SKILL_NAMES[number]);
+    return {
+      name, content, digest: digest(content), version: 1, source: "filesystem" as const,
+      metadata: {
+        protected: REQUIRED_NATIVE_SKILL_NAMES.includes(name as typeof REQUIRED_NATIVE_SKILL_NAMES[number]),
+        priority: priority >= 0 ? priority : 100,
+        categories: ["universal" as const],
+      },
+      files: { "SKILL.md": { content, digest: digest(content), encoding: "utf8" as const } },
+    };
+  }
+
+  it("materializes served agents alongside skills and reports them with an agent: prefix", async () => {
+    _resetSkillManifestSyncForTest();
+    const fixture = await tempRoot();
+    const agentsSkillsDir = join(fixture, "skills");
+    const claudeCodeAgentsDir = join(fixture, ".claude", "agents");
+    const skills = [...REQUIRED_NATIVE_SKILL_NAMES].map(skillEntry)
+      .sort((a, b) => a.metadata.priority - b.metadata.priority || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+    const snapshot: SkillManifest = {
+      schema_version: 1, generation_algorithm: "sha256-json-v1", complete: true, generation: "",
+      tier: "enterprise", routing_version: 42, skills,
+    };
+    snapshot.generation = computeSkillManifestGeneration(snapshot);
+    const scanner = definition("fast-scanner");
+    const payload = {
+      ...snapshot,
+      agents: [scanner],
+      agents_generation: digest("agents-gen-1"),
+    };
+
+    const result = await synchronizeSkillManifest({
+      agentsSkillsDir,
+      claudeCodeSkillsDir: false,
+      cursorSkillsDir: false,
+      claudeCodeAgentsDir,
+      applyManifest: vi.fn(async () => undefined),
+      fetchImpl: vi.fn(() => jsonResponse(payload)) as unknown as typeof fetch,
+      configuredCredential: true,
+      getJwt: async () => "valid-paid-jwt",
+    });
+
+    expect(result.status).toBe("applied");
+    expect(result.installed).toContain("agent:fast-scanner");
+    expect(await readFile(join(claudeCodeAgentsDir, "fast-scanner.md"), "utf8")).toBe(scanner.content);
+
+    // FROZEN CONTRACT: agents ride outside the skills generation. A payload
+    // whose agents perturbed `generation` would have failed validation above,
+    // so reaching "applied" here proves the server/client hash split holds.
+    expect(payload.generation).toBe(computeSkillManifestGeneration(snapshot));
+  });
+
+  it("fails the fetch loudly on a malformed agent section instead of pruning", async () => {
+    _resetSkillManifestSyncForTest();
+    const fixture = await tempRoot();
+    const agentsSkillsDir = join(fixture, "skills");
+    const claudeCodeAgentsDir = join(fixture, ".claude", "agents");
+    const scanner = definition("fast-scanner");
+    const skills = [...REQUIRED_NATIVE_SKILL_NAMES].map(skillEntry)
+      .sort((a, b) => a.metadata.priority - b.metadata.priority || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+    const snapshot: SkillManifest = {
+      schema_version: 1, generation_algorithm: "sha256-json-v1", complete: true, generation: "",
+      tier: "enterprise", routing_version: 42, skills,
+    };
+    snapshot.generation = computeSkillManifestGeneration(snapshot);
+
+    // Seed a managed agent, then serve a corrupt section: the file must survive.
+    await materializeAgentDefinitions(section(scanner), claudeCodeAgentsDir);
+    const corrupt = { ...snapshot, agents: [{ ...scanner, digest: digest("tampered") }], agents_generation: digest("g") };
+    const result = await synchronizeSkillManifest({
+      agentsSkillsDir,
+      claudeCodeSkillsDir: false,
+      cursorSkillsDir: false,
+      claudeCodeAgentsDir,
+      applyManifest: vi.fn(async () => undefined),
+      fetchImpl: vi.fn(() => jsonResponse(corrupt)) as unknown as typeof fetch,
+      configuredCredential: true,
+      getJwt: async () => "valid-paid-jwt",
+    });
+    expect(result.status).toBe("failed");
+    expect(await readFile(join(claudeCodeAgentsDir, "fast-scanner.md"), "utf8")).toBe(scanner.content);
+  });
+});


### PR DESCRIPTION
Materializes agent definitions served by the skill manifest (`agents` + `agents_generation` fields) into every detected host root:

- **Claude Code** `~/.claude/agents/<name>.md` — canonical bytes verbatim
- **Codex** `~/.codex/agents/<name>.toml` — keys verified against codex 0.146.0 (`developer_instructions`, `model_reasoning_effort`, `sandbox_mode`; Bash tools ⇒ workspace-write, effort xhigh/max ⇒ high)
- **Gemini CLI** `~/.gemini/agents/<name>.md` — reduced frontmatter, verified against gemini-cli 0.53.1 `loadAgentsFromDirectory`

Properties pinned by tests (25 new; 60/60 with the existing sync suite):
- Hand-edited or foreign files are NEVER overwritten or deleted — conflict + bytes preserved; byte-identical foreign files adopted without a write
- Ownership proven by digest via a per-root sidecar index (`.prism-agents.json`), never assumed
- Agents ride OUTSIDE the frozen skills `generation` hash (separate `agents_generation`), so pre-agents clients are unaffected and agent-less servers are tolerated — no deploy-order hazard
- A malformed agent section fails the fetch loudly instead of becoming a silent prune signal; per-host failures degrade to conflicts, never touching skill state
- Model tier deliberately does not travel to foreign hosts (namespaces rotate); only effort and tool-surface levers translate

Server counterpart: synalux-private feat/prism-agent-delivery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)