### PR TITLE
feat(registry): repair MCP registry manifest, ship plugin, automate republish

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "prism",
+  "interface": {
+    "displayName": "Prism"
+  },
+  "plugins": [
+    {
+      "name": "prism",
+      "source": {
+        "source": "local",
+        "path": "./plugins/prism"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Engineering"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "prism",
+  "description": "Prism — persistent session memory, knowledge search, and local-first inference for coding agents",
+  "owner": {
+    "name": "Synalux",
+    "email": "support@synalux.ai"
+  },
+  "plugins": [
+    {
+      "name": "prism",
+      "description": "Persistent session memory for Claude Code. Restores prior decisions, open TODOs, and changed files at the start of each session; adds knowledge search, goal-drift detection, and local-first inference. Memory stays in SQLite on your machine by default.",
+      "author": {
+        "name": "Synalux",
+        "email": "support@synalux.ai"
+      },
+      "category": "productivity",
+      "source": "./plugins/prism",
+      "homepage": "https://synalux.ai"
+    }
+  ]
+}

--- a/.github/workflows/registry-publish.yml
+++ b/.github/workflows/registry-publish.yml
@@ -1,0 +1,34 @@
+name: MCP Registry Publish
+# Root cause of the 1.5.0→20.6.0 registry drift: publishing was fully manual
+# and nothing ever republished after the initial listing. This workflow makes
+# the registry listing follow main: any change to server.json republishes via
+# GitHub OIDC (no stored secrets — the registry validates namespace ownership
+# against this repository).
+on:
+  push:
+    branches: [main]
+    paths: ["server.json"]
+  workflow_dispatch:
+
+permissions:
+  id-token: write # GitHub OIDC login to the MCP registry
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Guard — manifest must match package.json
+        run: node scripts/check-publish-clean.mjs --manifest-only || node -e "
+          const s=require('./server.json'), p=require('./package.json');
+          if (s.version !== p.version) { console.error('server.json '+s.version+' != package.json '+p.version); process.exit(1); }
+          console.log('manifest in sync:', s.version);"
+      - name: Install mcp-publisher
+        run: |
+          curl -fsSL https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz | tar xz
+          sudo mv mcp-publisher /usr/local/bin/
+      - name: Publish to MCP Registry
+        run: |
+          mcp-publisher login github-oidc
+          mcp-publisher publish

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,11 @@ REVIEW_PROMPT.md
 
 # MCP runtime config (contains API keys)
 .mcp.json
+# ...except a distributed plugin's server declaration, which is the whole point
+# of the plugin and carries no keys (npx invocation only). Without this
+# negation the published plugin installs its skills and registers no MCP
+# server at all.
+!plugins/*/.mcp.json
 
 # Build & environment
 node_modules/

--- a/plugins/prism/.claude-plugin/plugin.json
+++ b/plugins/prism/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "prism",
+  "description": "Persistent session memory for Claude Code. Prism restores what you were doing across sessions — decisions, open TODOs, changed files — and carries knowledge search, drift detection, and local-first inference. Memory stays in SQLite on your machine by default.",
+  "author": {
+    "name": "Synalux",
+    "email": "support@synalux.ai"
+  },
+  "homepage": "https://synalux.ai",
+  "repository": "https://github.com/dcostenco/prism-coder",
+  "license": "Apache-2.0",
+  "keywords": [
+    "memory",
+    "session-memory",
+    "context",
+    "knowledge-search",
+    "local-first",
+    "mcp"
+  ]
+}

--- a/plugins/prism/.codex-plugin/plugin.json
+++ b/plugins/prism/.codex-plugin/plugin.json
@@ -1,0 +1,33 @@
+{
+  "name": "prism",
+  "version": "20.6.0",
+  "description": "Persistent session memory for Codex. Prism restores what you were doing across sessions — decisions, open TODOs, changed files — and carries knowledge search, drift detection, and local-first inference. Memory stays in SQLite on your machine by default.\n\nOn the first user turn of a conversation, call session_bootstrap once before answering, then print its result verbatim as the startup display.",
+  "author": {
+    "name": "Synalux"
+  },
+  "homepage": "https://synalux.ai",
+  "repository": "https://github.com/dcostenco/prism-coder",
+  "license": "Apache-2.0",
+  "keywords": [
+    "memory",
+    "session-memory",
+    "context",
+    "knowledge-search",
+    "local-first",
+    "mcp"
+  ],
+  "mcpServers": "./.mcp.json",
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Prism",
+    "shortDescription": "Session memory that survives across conversations",
+    "longDescription": "Prism gives Codex a memory that outlives a single conversation. It restores prior decisions, open TODOs, and changed files at the start of each session, searches an indexed knowledge store, and detects when a long session has drifted from its original goal. Memory is stored in SQLite on your own machine by default; a subscription may be used instead for multi-device sync.",
+    "developerName": "Synalux",
+    "category": "Engineering",
+    "capabilities": ["Read", "Write"],
+    "websiteURL": "https://synalux.ai",
+    "defaultPrompt": [
+      "What was I working on last session?"
+    ]
+  }
+}

--- a/plugins/prism/.mcp.json
+++ b/plugins/prism/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "prism-mcp": {
+      "command": "npx",
+      "args": ["-y", "prism-mcp-server"]
+    }
+  }
+}

--- a/plugins/prism/skills/prism-startup/SKILL.md
+++ b/plugins/prism/skills/prism-startup/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: prism-startup
+description: "Activate on the first user turn of every conversation, including greetings. Load Prism context using the user's configured project and quick, standard, or deep depth, then greet the developer by their configured agent name and show the matching recent-session context."
+---
+
+# Prism Startup
+
+Use this skill once, on the first user turn of a conversation. A greeting such
+as "hi", "hello", or "ready?" is still a first user turn and must activate it.
+Do not run it again after startup context has already been shown in the same
+conversation.
+
+Portable native-skill activation starts when the host processes the first user
+turn. It cannot display anything before the developer sends that first input.
+That first-turn behavior is the cross-host contract.
+
+## Provisioning contract
+
+This skill ships with the `prism` plugin, alongside the Prism MCP server
+registration. The `prism connect` CLI installs the same protected skill for
+hosts configured that way; when both are present, the re-entry rule above keeps
+startup to a single display. Startup must not modify a host's lifecycle
+configuration. The skill remains available on every subscription tier, and it is
+intentionally absent from session skill routing so loading context cannot inject
+this startup procedure recursively.
+
+## First action: bootstrap context
+
+Before greeting the developer or answering their task:
+
+1. If `session_bootstrap` is available, call it with no arguments. Do not guess
+   a project, role, developer name, or context depth.
+2. If `session_bootstrap` is unavailable but `session_load_context` is
+   available, call `session_load_context` for the current project and omit the
+   `level` argument. Use the repository or workspace name as the project; use
+   `prism-mcp` only when no project can be derived.
+3. If MCP tools are unavailable but the `prism` CLI is available, run
+   `prism load <project> --json` and omit `--level`.
+4. If the first attempt fails, correct the parameters and retry once. If the
+   retry and fallback both fail, display exactly:
+   `⚠️ *Session context is temporarily unavailable.*`
+
+The level must be omitted in every startup path. Prism resolves the current
+dashboard setting instead of allowing this static skill to override it.
+
+## Context-depth contract
+
+Render only the data returned for the resolved depth:
+
+- `quick`: greet with the configured name and show the compact current state,
+  including open TODOs or keywords when present. Do not claim session summaries
+  were absent; quick intentionally does not fetch them.
+- `standard`: also show the last summary and up to five recent sessions.
+- `deep`: also show the complete returned session history, up to fifty entries,
+  including the extra decisions, TODOs, and changed-file detail supplied by
+  Prism.
+
+Do not make a second load call to expand the selected depth. An empty field is
+different from a field intentionally omitted at the selected depth.
+
+## Greeting and context output
+
+If `session_bootstrap` returns a ready-to-display greeting/context block, print
+the complete bootstrap result verbatim as the entire first-turn startup
+display, before any task answer. Do not summarize, paraphrase, rename headings,
+reformat, or omit any returned section. Preserve its order and line content.
+
+If no ready-to-display block is returned, render the structured fallback result
+in this order:
+
+1. `Hi, <agent_name>.` using the configured `agent_name`. If it is empty, use
+   `Hi.` without inventing a name.
+2. `**Last session:** <last_summary>` when the selected depth returned it.
+3. `**Open TODOs:**` followed by the returned TODOs, when present.
+4. `**Recent sessions:**` for standard results or `**Session history:**` for
+   deep results, preserving the returned order.
+
+When the first user input is only a greeting, stop after the verbatim startup
+display. If only the structured fallback was available, stop after that
+structured startup display. Do not add another greeting, question,
+acknowledgement, or other prose. When the first input contains a task, continue
+directly into that task after the startup display.
+
+## Foundational skill verification
+
+Context loading may return entitled `[📜 SKILL: <name>]` blocks. Use only the
+skills explicitly reported as provisioned or returned in those blocks. Never
+guess a package name, request a missing package, or treat a package from an old
+session as currently entitled. Paid behavioral and engineering packages are
+delivered by the authenticated manifest; the public startup path relies on the
+compact safety and evidence contract in the MCP server instructions.
+
+For bug reports or screenshots, run a real diagnostic before explaining the
+cause. Never report "done", "fixed", or "working" without observable
+verification.

--- a/scripts/__tests__/publish-manifest.test.mjs
+++ b/scripts/__tests__/publish-manifest.test.mjs
@@ -1,0 +1,85 @@
+/**
+ * MCP Registry manifest drift guard — node:test
+ * =============================================
+ * server.json is the storefront the MCP Registry serves, and it is the default
+ * place Claude Code and Codex users look for servers. On 2026-08-05 the live
+ * registry listing was 1.5.0, server.json said 2.3.4, and npm latest was
+ * 20.6.0 — nothing tied the files together, so the public listing drifted ~19
+ * majors behind the shipping build while every publish succeeded.
+ *
+ * Run: node --test scripts/__tests__/publish-manifest.test.mjs
+ * (from ~/prism)
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { serverManifestVersionMismatches } from "../check-publish-clean.mjs";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const readJson = (name) => JSON.parse(readFileSync(join(REPO_ROOT, name), "utf8"));
+
+describe("serverManifestVersionMismatches", () => {
+  it("reports the top-level version when it trails package.json", () => {
+    const problems = serverManifestVersionMismatches(
+      { name: "prism-mcp-server", version: "20.6.0" },
+      { version: "2.3.4", packages: [] },
+    );
+    assert.equal(problems.length, 1);
+    assert.match(problems[0], /server\.json version is 2\.3\.4, expected 20\.6\.0/);
+  });
+
+  it("reports a stale package entry even when the top-level version is current", () => {
+    const problems = serverManifestVersionMismatches(
+      { name: "prism-mcp-server", version: "20.6.0" },
+      {
+        version: "20.6.0",
+        packages: [{ identifier: "prism-mcp-server", version: "2.3.4" }],
+      },
+    );
+    assert.equal(problems.length, 1);
+    assert.match(problems[0], /packages\[0\]\.version is 2\.3\.4, expected 20\.6\.0/);
+  });
+
+  it("ignores package entries that are not this server's npm package", () => {
+    const problems = serverManifestVersionMismatches(
+      { name: "prism-mcp-server", version: "20.6.0" },
+      {
+        version: "20.6.0",
+        packages: [{ identifier: "some-other-package", version: "0.0.1" }],
+      },
+    );
+    assert.deepEqual(problems, []);
+  });
+
+  it("passes when every version agrees", () => {
+    const problems = serverManifestVersionMismatches(
+      { name: "prism-mcp-server", version: "20.6.0" },
+      {
+        version: "20.6.0",
+        packages: [{ identifier: "prism-mcp-server", version: "20.6.0" }],
+      },
+    );
+    assert.deepEqual(problems, []);
+  });
+});
+
+describe("the committed server.json", () => {
+  it("advertises the version this repo actually publishes", () => {
+    assert.deepEqual(
+      serverManifestVersionMismatches(readJson("package.json"), readJson("server.json")),
+      [],
+    );
+  });
+
+  it("points at the repository that actually hosts this server", () => {
+    const { repository } = readJson("server.json");
+    // The registry validates namespace ownership against this URL; the old
+    // value (dcostenco/prism-mcp) is now only a GitHub rename redirect.
+    assert.equal(repository.url, "https://github.com/dcostenco/prism-coder");
+    assert.equal(repository.source, "github");
+  });
+});

--- a/scripts/check-publish-clean.mjs
+++ b/scripts/check-publish-clean.mjs
@@ -1,6 +1,39 @@
 #!/usr/bin/env node
 
 import { execFileSync } from "node:child_process";
+import { readFileSync, realpathSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Every version the MCP Registry serves for this server, so a publish cannot
+ * ship a listing that disagrees with the npm tarball.
+ *
+ * Why this guard exists (2026-08-05): the registry advertised 1.5.0 and
+ * server.json carried 2.3.4 while npm latest was 20.6.0. Nothing tied the two
+ * files together, so the public discovery surface — the default place Claude
+ * and Codex users look for servers — silently drifted ~19 majors behind the
+ * shipping build. The failure was invisible because npm publish succeeded
+ * every time; only the storefront was stale.
+ */
+export function serverManifestVersionMismatches(packageJson, serverJson) {
+  const expected = packageJson.version;
+  const problems = [];
+  if (serverJson.version !== expected) {
+    problems.push(`server.json version is ${serverJson.version}, expected ${expected}`);
+  }
+  for (const [index, pkg] of (serverJson.packages ?? []).entries()) {
+    if (pkg.identifier === packageJson.name && pkg.version !== expected) {
+      problems.push(`server.json packages[${index}].version is ${pkg.version}, expected ${expected}`);
+    }
+  }
+  return problems;
+}
+
+function checkServerManifest(repoRoot) {
+  const read = (name) => JSON.parse(readFileSync(join(repoRoot, name), "utf8"));
+  return serverManifestVersionMismatches(read("package.json"), read("server.json"));
+}
 
 function workingTreeStatus(repoRoot) {
   return execFileSync(
@@ -14,18 +47,42 @@ function workingTreeStatus(repoRoot) {
   ).trim();
 }
 
-try {
-  const status = workingTreeStatus(process.cwd());
-  if (status) {
-    console.error(
-      "npm publish blocked: the Prism working tree is not clean.\n" +
-        "Commit, move, or restore every change before publishing:\n" +
-        status,
-    );
+// Only gate when run as the prepublishOnly script. Importing this module —
+// which the regression test does — must stay side-effect free, or the checks
+// below would run against the test's cwd and set a failing exit code.
+const IS_MAIN = process.argv[1]
+  && realpathSync(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (IS_MAIN) {
+  try {
+    const status = workingTreeStatus(process.cwd());
+    if (status) {
+      console.error(
+        "npm publish blocked: the Prism working tree is not clean.\n" +
+          "Commit, move, or restore every change before publishing:\n" +
+          status,
+      );
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`npm publish blocked: unable to verify Git state: ${message}`);
     process.exitCode = 1;
   }
-} catch (error) {
-  const message = error instanceof Error ? error.message : String(error);
-  console.error(`npm publish blocked: unable to verify Git state: ${message}`);
-  process.exitCode = 1;
+
+  try {
+    const problems = checkServerManifest(process.cwd());
+    if (problems.length) {
+      console.error(
+        "npm publish blocked: server.json disagrees with package.json.\n" +
+          "The MCP Registry listing would ship stale versions:\n  " +
+          problems.join("\n  "),
+      );
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`npm publish blocked: unable to verify server.json: ${message}`);
+    process.exitCode = 1;
+  }
 }

--- a/scripts/check-publish-clean.mjs
+++ b/scripts/check-publish-clean.mjs
@@ -31,8 +31,20 @@ export function serverManifestVersionMismatches(packageJson, serverJson) {
 }
 
 function checkServerManifest(repoRoot) {
-  const read = (name) => JSON.parse(readFileSync(join(repoRoot, name), "utf8"));
-  return serverManifestVersionMismatches(read("package.json"), read("server.json"));
+  // A repo without a registry manifest has nothing to drift: repos that never
+  // published to the MCP Registry (and the guard's own test fixtures) must
+  // pass untouched. Only an EXISTING manifest is held to the sync contract —
+  // a present-but-corrupt server.json still fails loudly via the caller.
+  let rawServer;
+  let rawPackage;
+  try {
+    rawServer = readFileSync(join(repoRoot, "server.json"), "utf8");
+    rawPackage = readFileSync(join(repoRoot, "package.json"), "utf8");
+  } catch (error) {
+    if (error && error.code === "ENOENT") return [];
+    throw error;
+  }
+  return serverManifestVersionMismatches(JSON.parse(rawPackage), JSON.parse(rawServer));
 }
 
 function workingTreeStatus(repoRoot) {

--- a/server.json
+++ b/server.json
@@ -3,15 +3,16 @@
   "name": "io.github.dcostenco/prism-mcp",
   "description": "Session memory, knowledge search, Brave Search, Gemini AI, and code transforms for AI agents",
   "repository": {
-    "url": "https://github.com/dcostenco/prism-mcp",
+    "url": "https://github.com/dcostenco/prism-coder",
     "source": "github"
   },
-  "version": "2.3.4",
+  "version": "20.6.0",
   "packages": [
     {
       "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "prism-mcp-server",
-      "version": "2.3.4",
+      "version": "20.6.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Takeover of the registry work stream. The public MCP Registry still serves **1.5.0** while npm ships **20.6.0** — publishing was fully manual with zero automation, which is the root cause of the 19-major drift.

- `server.json` → 20.6.0, repository URL → `dcostenco/prism-coder` (registry validates namespace ownership against it)
- `check-publish-clean.mjs` blocks `npm publish` on manifest/package version mismatch (6/6 tests via `node --test`)
- `plugins/prism`: one dir serving Claude Code + Codex marketplaces; free-tier `prism-startup` skill only — no paid content in this public repo; `.gitignore` negation keeps the plugin's `.mcp.json` publishable
- `registry-publish.yml`: server.json changes on main → republish via GitHub OIDC

Post-merge steps: first workflow run (or manual `mcp-publisher publish`) updates the live listing; then the claude-plugins-official submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)