### PR TITLE
fix(registry): align server.json name with the shipped npm mcpName

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.dcostenco/prism-mcp",
+  "name": "io.github.dcostenco/prism-coder",
   "description": "Session memory, knowledge search, Brave Search, Gemini AI, and code transforms for AI agents",
   "repository": {
     "url": "https://github.com/dcostenco/prism-coder",


### PR DESCRIPTION
npm prism-mcp-server@20.6.0 already declares
mcpName io.github.dcostenco/prism-coder (the repo's post-rename
identity), and registry ownership validation requires server.json's
name to match the published tarball. Publishing therefore lands on the
prism-coder listing; the legacy io.github.dcostenco/prism-mcp entry
(stuck at 1.5.0) cannot be updated without republishing npm under the
old name and is left as a documented orphan.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
