### PR TITLE
feat(onboarding): make the first run demonstrate value instead of absence

### DIFF
--- a/src/tools/ledgerHandlers.ts
+++ b/src/tools/ledgerHandlers.ts
@@ -25,6 +25,7 @@ import { buildVaultDirectory } from "../utils/vaultExporter.js";
  */
 
 import { debugLog } from "../utils/logger.js";
+import { FREE_ENTITLEMENTS } from "../utils/entitlements.js";
 import { getStorage, activeStorageBackend } from "../storage/index.js";
 import { toKeywordArray } from "../utils/keywordExtractor.js";
 import { getLLMProvider } from "../utils/llm/factory.js";
@@ -376,7 +377,8 @@ async function buildNativeSystemReadyBlock(
       `> - 🛠️ **Other tier entitlements:** ${formatBoundedSkillNames(otherTierSkills, "entitled")}\n` +
       `> - 🧠 **Context depth:** ${depth}\n` +
       `> - 🔄 **Skill sync:** ${SKILL_SYNC_STATUS_LABELS[snapshot.syncStatus]} · native materialization incomplete${conflictSuffix}` +
-      conflictWarning;
+      conflictWarning +
+      freeTierUpgradeLine(snapshot.tier);
   }
   if (snapshot.source === "tier-fallback") {
     return `> **Prism System Ready**\n>\n` +
@@ -384,7 +386,8 @@ async function buildNativeSystemReadyBlock(
       `> - 🛡️ **Fallback skill names:** ${formatBoundedSkillNames(snapshot.names, "fallback")}\n` +
       `> - 🧠 **Context depth:** ${depth}\n` +
       `> - 🔄 **Skill sync:** ${SKILL_SYNC_STATUS_LABELS[snapshot.syncStatus]} · no committed manifest${conflictSuffix}` +
-      conflictWarning;
+      conflictWarning +
+      freeTierUpgradeLine(snapshot.tier);
   }
   return `> **Prism System Ready**\n>\n` +
     `> - 🪪 **Subscription tier:** ${snapshot.tier}\n` +
@@ -394,7 +397,37 @@ async function buildNativeSystemReadyBlock(
     `> - 🛠️ **Other tier skills provisioned:** ${formatBoundedSkillNames(otherTierSkills, "provisioned")}\n` +
     `> - 🧠 **Context depth:** ${depth}\n` +
     `> - 🔄 **Skill sync:** ${SKILL_SYNC_STATUS_LABELS[snapshot.syncStatus]} · committed manifest${conflictSuffix}` +
-    conflictWarning;
+    conflictWarning +
+    freeTierUpgradeLine(snapshot.tier);
+}
+
+/**
+ * The paid funnel's one startup line. Before 2026-08-05 the upgrade_url was
+ * surfaced only AFTER a user hit an entitlement gate (sessionDriftHandler,
+ * queryMemoryNaturalHandler); the startup path — the only guaranteed
+ * impression — referenced it zero times.
+ */
+function freeTierUpgradeLine(tier: string): string {
+  if (tier !== "free") return "";
+  return `\n> - 💎 **Free tier:** paid plans unlock the full skill library, ` +
+    `super-skills, and agent routing → ${FREE_ENTITLEMENTS.upgrade_url}`;
+}
+
+/**
+ * Dashboard URL for startup output. The bound port is announced on stderr
+ * only (MCP stdio owns stdout), so users never saw it; the dashboard also
+ * writes the port to ~/.prism-mcp/dashboard.port — read that, then the env
+ * override, then the default.
+ */
+function readDashboardUrl(): string {
+  let port = process.env.PRISM_DASHBOARD_PORT || "3000";
+  try {
+    const recorded = fs.readFileSync(nodePath.join(os.homedir(), ".prism-mcp", "dashboard.port"), "utf8").trim();
+    if (/^\d{2,5}$/.test(recorded)) port = recorded;
+  } catch {
+    // port file absent — dashboard not started yet this boot; defaults hold
+  }
+  return `http://localhost:${port}`;
 }
 
 function capNativeStartupText(
@@ -1916,16 +1949,42 @@ export async function sessionBootstrapHandler(
   const role = sanitizeNativeIdentity(defaultRole) || "global";
   const manifestSnapshot = await resolveNativeSkillManifestSnapshot(skillSyncResult);
   const systemReadyBlock = await buildNativeSystemReadyBlock(manifestSnapshot, depth);
-  const greeting = `👋 Welcome back, ${greetingName}. Prism is loading ${depth} context.`;
+  // First run = the dashboard has never been touched: no agent identity AND no
+  // projects. Measured 2026-08-05: a brand-new free-tier install was greeted
+  // with "Welcome back", three "Not loaded" rows, a warning, and three
+  // statements of what it doesn't have — an all-absence payload with no next
+  // step, no dashboard URL (stderr-only), and no path to the paid tier.
+  const isFirstRun = projects.length === 0 && !configuredGreetingName;
+  const greeting = isFirstRun
+    ? `👋 Welcome to Prism — first run detected. Let's get you productive in a few minutes.`
+    : `👋 Welcome back, ${greetingName}. Prism is loading ${depth} context.`;
   const identityBlock = `- 🤖 **Agent Identity:** ${escapeNativeMarkdown(compactWithOmissionCount(role, 80))} — ${greetingName}`;
-  const startupHeader = `${greeting}\n\n${identityBlock}`;
+  const startupHeader = isFirstRun ? greeting : `${greeting}\n\n${identityBlock}`;
 
   if (projects.length === 0) {
+    const dashboardLine = `- 🎛️ **Dashboard:** ${readDashboardUrl()} — configure projects, identity, and context depth`;
+    if (isFirstRun) {
+      // Action-first instead of absence-first: every line is a capability or
+      // a next step. The wizard exists and is well-built; route to it.
+      const firstRunText = `${greeting}\n\n` +
+        `- 🚀 **Get started:** run the \`onboarding_wizard\` tool (guided setup, ~3 minutes)\n` +
+        `${dashboardLine}\n` +
+        `- 💾 **Already working?** \`session_save_ledger\` records this session; the next one resumes with full context\n\n` +
+        `${systemReadyBlock}`;
+      return {
+        content: [{
+          type: "text",
+          text: capNativeStartupText(firstRunText, depth),
+        }],
+        isError: false,
+        structuredContent: { conversation_id: conversationId, projects: [], depth, first_run: true },
+      };
+    }
     const unconfiguredState = (depth === "quick" ? "" : `\n- 📝 **Last Session Summary:** Not loaded`) +
       `\n- ✅ **Open TODOs:** Not loaded` +
       `\n- 🔄 **Session Version:** Not loaded`;
     const noProjectsText = `${startupHeader}${unconfiguredState}\n\n` +
-      `⚠️ No Auto-Load Projects are configured in the Prism dashboard.\n\n${systemReadyBlock}`;
+      `⚠️ No Auto-Load Projects are configured in the Prism dashboard.\n${dashboardLine}\n\n${systemReadyBlock}`;
     return {
       content: [{
         type: "text",

--- a/src/tools/sessionMemoryDefinitions.ts
+++ b/src/tools/sessionMemoryDefinitions.ts
@@ -1640,8 +1640,8 @@ export const ONBOARDING_WIZARD_TOOL: Tool = {
     "Interactive setup wizard for new Prism users. Provides a step-by-step " +
     "guided experience to get productive in under 3 minutes.\n\n" +
     "**Actions:**\n" +
-    "- `start` — Begin the wizard from step 1\n" +
-    "- `next` — Advance to the next step\n" +
+    "- `start` (default when omitted) — Begin the wizard from step 1\n" +
+    "- `next` — Advance past `step` (pass the step number you are on)\n" +
     "- `status` — Check current wizard progress\n" +
     "- `skip` — Skip to completion\n\n" +
     "Each step returns instructions, code snippets, and progress percentage.",
@@ -1651,7 +1651,12 @@ export const ONBOARDING_WIZARD_TOOL: Tool = {
       action: {
         type: "string",
         enum: ["start", "next", "status", "skip"],
-        description: "Wizard action to perform.",
+        description: "Wizard action to perform. Omitted = start.",
+      },
+      step: {
+        type: "integer",
+        minimum: 0,
+        description: "The step_index from the previous response; used by `next` and `status`.",
       },
       project_name: {
         type: "string",
@@ -1663,12 +1668,12 @@ export const ONBOARDING_WIZARD_TOOL: Tool = {
         description: "IDE client for config generation.",
       },
     },
-    required: ["action"],
   },
 };
 
 export interface OnboardingWizardArgs {
-  action: "start" | "next" | "status" | "skip";
+  action?: "start" | "next" | "status" | "skip";
+  step?: number;
   project_name?: string;
   ide_client?: string;
 }
@@ -1678,8 +1683,15 @@ export function isOnboardingWizardArgs(
 ): args is OnboardingWizardArgs {
   if (typeof args !== "object" || args === null) return false;
   const a = args as Record<string, unknown>;
-  if (typeof a.action !== "string") return false;
-  if (!["start", "next", "status", "skip"].includes(a.action)) return false;
+  // A bare call is the front door for brand-new users (the startup greeting
+  // routes here) — it must work, defaulting to `start`. Measured 2026-08-05:
+  // requiring `action` made the tool the first thing a new user touches AND
+  // the first error they see.
+  if (a.action !== undefined &&
+      (typeof a.action !== "string" || !["start", "next", "status", "skip"].includes(a.action))) {
+    return false;
+  }
+  if (a.step !== undefined && (!Number.isInteger(a.step) || (a.step as number) < 0)) return false;
   if (a.project_name !== undefined && typeof a.project_name !== "string") return false;
   if (a.ide_client !== undefined && typeof a.ide_client !== "string") return false;
   return true;

--- a/src/tools/v12Handlers.ts
+++ b/src/tools/v12Handlers.ts
@@ -20,6 +20,8 @@ import {
 
 // ─── Onboarding Wizard Handler ───────────────────────────────
 
+type OnboardingWizardAction = "start" | "next" | "status" | "skip";
+
 export async function onboardingWizardHandler(args: Record<string, unknown>) {
     if (!isOnboardingWizardArgs(args)) {
         return {
@@ -28,7 +30,18 @@ export async function onboardingWizardHandler(args: Record<string, unknown>) {
         };
     }
 
-    const { step, responses } = args;
+    // The schema advertises action-based navigation while this handler
+    // historically read `{step, responses}` — fields the validator never
+    // passed, so `next`/`status`/`skip` all silently rendered step 1 and a
+    // bare call was rejected outright (measured 2026-08-05). Map the
+    // advertised contract onto the stateless wizard: the client carries the
+    // step number between calls.
+    const action = (args.action as OnboardingWizardAction | undefined) ?? "start";
+    const currentStep = typeof args.step === "number" ? args.step : 0;
+    const step = action === "start" ? undefined
+        : action === "next" ? currentStep + 1
+        : action === "status" ? currentStep
+        : Number.MAX_SAFE_INTEGER; // skip → past the final step = completion
 
     try {
         const wizard = await import("../onboarding/wizard.js");
@@ -43,6 +56,7 @@ export async function onboardingWizardHandler(args: Record<string, unknown>) {
                     text: JSON.stringify({
                         status: "in_progress",
                         current_step: state.currentStep,
+                        step_index: 0,
                         total_steps: 8,
                         step: content,
                         summary: wizard.getWizardSummary(state),
@@ -51,12 +65,15 @@ export async function onboardingWizardHandler(args: Record<string, unknown>) {
             };
         }
 
-        // Advance to next step
+        // Advance to the requested step position. Wizard steps are NAMED
+        // ("welcome", "storage", …); the numeric step_index in every response
+        // is what clients echo back for `next`/`status`.
         const state = wizard.createWizardState();
-        // Advance to the requested step position
         let currentState = state;
-        for (let i = 0; i < (step as number); i++) {
+        let stepIndex = 0;
+        for (let i = 0; i < step && !wizard.isWizardComplete(currentState); i++) {
             currentState = wizard.advanceWizard(currentState);
+            stepIndex += 1;
         }
 
         if (wizard.isWizardComplete(currentState)) {
@@ -84,6 +101,7 @@ export async function onboardingWizardHandler(args: Record<string, unknown>) {
                 text: JSON.stringify({
                     status: "in_progress",
                     current_step: currentState.currentStep,
+                    step_index: stepIndex,
                     step: content,
                     summary: wizard.getWizardSummary(currentState),
                 }, null, 2),

--- a/tests/tools/ledgerHandlers.test.ts
+++ b/tests/tools/ledgerHandlers.test.ts
@@ -1026,6 +1026,47 @@ describe("ledgerHandlers", () => {
   });
 
   describe("sessionBootstrapHandler", () => {
+    it("greets a first run with actions and the paid CTA, never with absence", async () => {
+      // First run = dashboard never touched: no agent identity, no projects.
+      mockGetSetting.mockImplementation(async (key: string, fallback = "") => ({
+        "skill_manifest:tier": "free",
+        "skill_manifest:names": JSON.stringify(["prism-startup"]),
+      }[key] ?? fallback));
+
+      const result = await sessionBootstrapHandler({});
+      const text = result.content[0].text as string;
+
+      expect(text).toContain("Welcome to Prism");
+      expect(text).toContain("onboarding_wizard");
+      expect(text).toContain("http://localhost");
+      // The paid funnel's one guaranteed impression (2026-08-05 first-run
+      // audit: the startup path referenced upgrade_url zero times).
+      expect(text).toContain("https://synalux.ai/pricing");
+      expect(result.structuredContent).toMatchObject({ first_run: true, projects: [] });
+      // The measured 2026-08-05 failure mode: "Welcome back" to a stranger
+      // followed by three "Not loaded" rows — an all-absence payload.
+      expect(text).not.toContain("Welcome back");
+      expect(text).not.toContain("Not loaded");
+    });
+
+    it("keeps the returning-user shape when an identity exists without projects, adding the dashboard URL", async () => {
+      mockGetSetting.mockImplementation(async (key: string, fallback = "") => ({
+        agent_name: "Dmitri",
+        "skill_manifest:tier": "enterprise",
+        "skill_manifest:names": JSON.stringify(["prism-startup"]),
+      }[key] ?? fallback));
+
+      const result = await sessionBootstrapHandler({});
+      const text = result.content[0].text as string;
+
+      expect(text).toContain("Welcome back, Dmitri");
+      expect(text).toContain("Not loaded");
+      expect(text).toContain("http://localhost");
+      expect(result.structuredContent).not.toMatchObject({ first_run: true });
+      // Paid tiers never see the upgrade line.
+      expect(text).not.toContain("https://synalux.ai/pricing");
+    });
+
     it.each([
       ["quick", false, false],
       ["standard", true, true],
@@ -1327,9 +1368,13 @@ describe("ledgerHandlers", () => {
       const result = await sessionBootstrapHandler({});
       const text = result.content[0].text as string;
 
-      expect(text).toContain("Welcome back, developer");
-      expect(text).toContain("Agent Identity:** global — developer");
+      // Truthful now means honest about being NEW: no identity + no projects
+      // is a first run, and "Welcome back, developer" to a stranger was the
+      // 2026-08-05 first-run audit's headline defect.
+      expect(text).toContain("Welcome to Prism");
+      expect(text).not.toContain("Welcome back");
       expect(text).not.toContain("None — None");
+      expect(result.structuredContent).toMatchObject({ first_run: true });
     });
 
     it.each(BOOTSTRAP_TIER_DEPTH_CASES)(

--- a/tests/tools/onboarding-wizard.test.ts
+++ b/tests/tools/onboarding-wizard.test.ts
@@ -1,0 +1,59 @@
+/**
+ * The wizard is the first tool a brand-new user touches (the first-run
+ * greeting routes here). Before 2026-08-05 it was doubly broken: the schema
+ * required `action` (so the documented bare call was the first error a new
+ * user ever saw), and the handler read `{step, responses}` — fields the
+ * validator never passed — so `next`/`status`/`skip` all silently rendered
+ * step 1. These tests pin the advertised action contract to real behavior.
+ */
+import { describe, expect, it } from "vitest";
+import { onboardingWizardHandler } from "../../src/tools/v12Handlers.js";
+
+function parse(result: { content: Array<{ text?: string }>; isError?: boolean }) {
+  expect(result.isError).not.toBe(true);
+  return JSON.parse(result.content[0].text ?? "{}");
+}
+
+describe("onboarding_wizard action contract", () => {
+  it("treats a bare call as start — the first-run front door must never error", async () => {
+    const body = parse(await onboardingWizardHandler({}));
+    expect(body.status).toBe("in_progress");
+    expect(body.total_steps).toBe(8);
+    expect(body.step).toBeTruthy();
+  });
+
+  it("start and explicit action:'start' agree", async () => {
+    const bare = parse(await onboardingWizardHandler({}));
+    const explicit = parse(await onboardingWizardHandler({ action: "start" }));
+    expect(explicit.current_step).toBe(bare.current_step);
+    expect(bare.step_index).toBe(0);
+  });
+
+  it("next advances past the supplied step_index instead of re-rendering step 1", async () => {
+    const first = parse(await onboardingWizardHandler({ action: "start" }));
+    const second = parse(await onboardingWizardHandler({ action: "next", step: first.step_index }));
+    expect(second.status).toBe("in_progress");
+    expect(second.step_index).toBeGreaterThan(first.step_index);
+    expect(second.current_step).not.toBe(first.current_step);
+  });
+
+  it("status re-renders the supplied step_index without advancing", async () => {
+    const first = parse(await onboardingWizardHandler({ action: "start" }));
+    const advanced = parse(await onboardingWizardHandler({ action: "next", step: first.step_index }));
+    const status = parse(await onboardingWizardHandler({ action: "status", step: advanced.step_index }));
+    expect(status.current_step).toBe(advanced.current_step);
+    expect(status.step_index).toBe(advanced.step_index);
+  });
+
+  it("skip completes the wizard", async () => {
+    const body = parse(await onboardingWizardHandler({ action: "skip" }));
+    expect(body.status).toBe("completed");
+  });
+
+  it("still rejects a malformed action or negative step", async () => {
+    for (const args of [{ action: "bogus" }, { step: -1 }, { action: 42 }]) {
+      const result = await onboardingWizardHandler(args as Record<string, unknown>);
+      expect(result.isError).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Fixes the first-run audit findings that held the plugins-official submission:

**Before** (measured, scrubbed env): 'Welcome back' to a stranger → three 'Not loaded' rows → warning → three statements of absence. No CTA, no dashboard URL (stderr-only), and `onboarding_wizard` rejected its own documented bare call while every valid action re-rendered step 1.

**After** (verified over real stdio against this build):
```
👋 Welcome to Prism — first run detected. Let's get you productive in a few minutes.
- 🚀 Get started: run the onboarding_wizard tool (guided setup, ~3 minutes)
- 🎛️ Dashboard: http://localhost:3000 — configure projects, identity, and context depth
- 💾 Already working? session_save_ledger records this session…
```
plus `first_run: true` in structuredContent and the paid `upgrade_url` on every free-tier render branch.

Tests: 3775 full-suite + 6 new wizard-contract cases + 2 new bootstrap cases; the old 'Welcome back, developer' fallback assertion updated to the new truthful contract.

Unblocks: claude-plugins-official submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)