### PR TITLE
fix: resolve adversarial review findings (CLA bypass, silent agent-delivery failure, entitlement gap, fail-open publish gate)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -25,4 +25,4 @@ jobs:
           path-to-signatures: "signatures/cla.json"
           path-to-document: "CLA.md"
           branch: "cla-signatures"
-          allowlist: "dependabot[bot],github-actions[bot],dcostenco,Synalux AI"
+          allowlist: "dependabot[bot],github-actions[bot],dcostenco"

--- a/.github/workflows/registry-publish.yml
+++ b/.github/workflows/registry-publish.yml
@@ -19,14 +19,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # No `||` fallback: the fallback only compared top-level versions, so a
+      # stale packages[].version failed the real guard and then PASSED the
+      # fallback — a publish gate that fails open is not a gate.
       - name: Guard — manifest must match package.json
-        run: node scripts/check-publish-clean.mjs --manifest-only || node -e "
-          const s=require('./server.json'), p=require('./package.json');
-          if (s.version !== p.version) { console.error('server.json '+s.version+' != package.json '+p.version); process.exit(1); }
-          console.log('manifest in sync:', s.version);"
+        run: node scripts/check-publish-clean.mjs
       - name: Install mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.8.0
+          MCP_PUBLISHER_SHA256: 1370446bbe74d562608e8005a6ccce02d146a661fbd78674e11cc70b9618d6cf
         run: |
-          curl -fsSL https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_linux_amd64.tar.gz | tar xz
+          # Pinned + checksum-verified: this job holds id-token: write for the
+          # registry namespace, so an unpinned `latest` tarball would run
+          # arbitrary future code with publish credentials.
+          curl -fsSL -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz
           sudo mv mcp-publisher /usr/local/bin/
       - name: Publish to MCP Registry
         run: |

--- a/src/agentManifestSync.ts
+++ b/src/agentManifestSync.ts
@@ -297,6 +297,18 @@ async function installExclusive(dir: string, target: string, content: string): P
     return true;
   } catch (error) {
     if (isErrno(error, "EEXIST")) return false;
+    // Filesystems without hard-link support (exFAT/FAT32, several SMB and
+    // container-volume mounts) reject link(2) outright. Without this fallback
+    // those users receive ZERO agent definitions and only a stderr line —
+    // the exclusivity hardening would have silently disabled the feature.
+    // rename(2) is marginally weaker against a concurrent writer inside the
+    // check→act window; delivering nothing is strictly worse.
+    if (isErrno(error, "EPERM") || isErrno(error, "ENOTSUP") ||
+        isErrno(error, "EOPNOTSUPP") || isErrno(error, "EXDEV")) {
+      if (await currentDigest(target) !== null) return false;
+      await rename(temp, target);
+      return true;
+    }
     throw error;
   } finally {
     await rm(temp, { force: true });

--- a/src/skillManifestSync.ts
+++ b/src/skillManifestSync.ts
@@ -911,6 +911,37 @@ async function acquireSyncLock(agentsSkillsDir: string, waitMs = LOCK_WAIT_MS): 
   };
 }
 
+/**
+ * Converge every detected host's agent root onto the portal-validated agent
+ * section. Prefixed outcomes per host; a failure on one host degrades to a
+ * conflict rather than aborting the others or the skill result.
+ */
+async function materializeAgentsAcrossHosts(
+  section: AgentSection,
+  options: SkillSyncOptions,
+): Promise<Pick<SkillSyncResult, "installed" | "updated" | "pruned" | "conflicts">> {
+  const result = { installed: [] as string[], updated: [] as string[], pruned: [] as string[], conflicts: [] as string[] };
+  const hostTargets = [
+    { prefix: "agent", dir: await resolveClaudeAgentsDir(options), render: renderClaudeAgent },
+    { prefix: "agent-codex", dir: await resolveCodexAgentsDir(options), render: renderCodexAgent },
+    { prefix: "agent-gemini", dir: await resolveGeminiAgentsDir(options), render: renderGeminiAgent },
+  ];
+  for (const host of hostTargets) {
+    if (!host.dir) continue;
+    try {
+      const outcome = await materializeAgentDefinitions(section, host.dir, host.render);
+      result.installed.push(...outcome.installed.map((name) => `${host.prefix}:${name}`));
+      result.updated.push(...outcome.updated.map((name) => `${host.prefix}:${name}`));
+      result.pruned.push(...outcome.pruned.map((name) => `${host.prefix}:${name}`));
+      result.conflicts.push(...outcome.conflicts.map((name) => `${host.prefix}:${name}`));
+    } catch (error) {
+      console.error(`[Prism Skill Sync] ${host.prefix} materialization failed: ${error instanceof Error ? error.message : String(error)}`);
+      result.conflicts.push(`${host.prefix}:sync-failed`);
+    }
+  }
+  return result;
+}
+
 export async function synchronizeSkillManifest(options: SkillSyncOptions = {}): Promise<SkillSyncResult> {
   const empty = { installed: [], updated: [], pruned: [], conflicts: [] };
   let nativeSkillsDirs: string[] = [];
@@ -955,24 +986,11 @@ export async function synchronizeSkillManifest(options: SkillSyncOptions = {}): 
     // prefix. A failure on one host never rolls back skill state or the
     // other hosts — it surfaces as a conflict instead.
     if (manifest.agentSection) {
-      const hostTargets = [
-        { prefix: "agent", dir: await resolveClaudeAgentsDir(options), render: renderClaudeAgent },
-        { prefix: "agent-codex", dir: await resolveCodexAgentsDir(options), render: renderCodexAgent },
-        { prefix: "agent-gemini", dir: await resolveGeminiAgentsDir(options), render: renderGeminiAgent },
-      ];
-      for (const host of hostTargets) {
-        if (!host.dir) continue;
-        try {
-          const outcome = await materializeAgentDefinitions(manifest.agentSection, host.dir, host.render);
-          native.installed.push(...outcome.installed.map((name) => `${host.prefix}:${name}`));
-          native.updated.push(...outcome.updated.map((name) => `${host.prefix}:${name}`));
-          native.pruned.push(...outcome.pruned.map((name) => `${host.prefix}:${name}`));
-          native.conflicts.push(...outcome.conflicts.map((name) => `${host.prefix}:${name}`));
-        } catch (error) {
-          console.error(`[Prism Skill Sync] ${host.prefix} materialization failed: ${error instanceof Error ? error.message : String(error)}`);
-          native.conflicts.push(`${host.prefix}:sync-failed`);
-        }
-      }
+      const outcome = await materializeAgentsAcrossHosts(manifest.agentSection, options);
+      native.installed.push(...outcome.installed);
+      native.updated.push(...outcome.updated);
+      native.pruned.push(...outcome.pruned);
+      native.conflicts.push(...outcome.conflicts);
     }
     const status = native.installed.length || native.updated.length || native.pruned.length ? "applied" : "unchanged";
     return {
@@ -995,6 +1013,18 @@ export async function synchronizeSkillManifest(options: SkillSyncOptions = {}): 
         await enforceNativeEntitlements(entitledNames, nativeSkillsDir);
       } catch (enforcement) {
         enforcementErrors.push(`${nativeSkillsDir}: ${enforcement instanceof Error ? enforcement.message : String(enforcement)}`);
+      }
+      // Agent definitions need the SAME downgrade guarantee as skills. Without
+      // this, a tier downgrade whose DB apply throws prunes paid skills but
+      // leaves paid agent definitions in every host root until some later
+      // successful sync — exactly the local-fault-becomes-entitlement-bypass
+      // the skill path above exists to prevent.
+      if (manifest.agentSection) {
+        try {
+          await materializeAgentsAcrossHosts(manifest.agentSection, options);
+        } catch (enforcement) {
+          enforcementErrors.push(`agents: ${enforcement instanceof Error ? enforcement.message : String(enforcement)}`);
+        }
       }
       enforcementError = enforcementErrors.length > 0
         ? `; entitlement cleanup failed: ${enforcementErrors.join(", ")}`

--- a/src/tools/ledgerHandlers.ts
+++ b/src/tools/ledgerHandlers.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as nodePath from "node:path";
 import * as os from "node:os";
+import * as net from "node:net";
 import { randomUUID } from "node:crypto";
 import { redactSettings, toMarkdown } from "./commonHelpers.js";
 import { scanAndRedactPHI } from "../utils/phiGuard.js";
@@ -30,7 +31,7 @@ import { getStorage, activeStorageBackend } from "../storage/index.js";
 import { toKeywordArray } from "../utils/keywordExtractor.js";
 import { getLLMProvider } from "../utils/llm/factory.js";
 import { getCurrentGitState, getGitDrift } from "../utils/git.js";
-import { getSetting, getAllSettings, refreshConfigStorageCache } from "../storage/configStorage.js";
+import { getSetting, setSetting, getAllSettings, refreshConfigStorageCache } from "../storage/configStorage.js";
 import type { SkillSyncResult } from "../skillManifestSync.js";
 import { mergeHandoff, dbToHandoffSchema, sanitizeForMerge } from "../utils/crdtMerge.js";
 import { resolveProject } from "../utils/projectResolver.js";
@@ -419,15 +420,37 @@ function freeTierUpgradeLine(tier: string): string {
  * writes the port to ~/.prism-mcp/dashboard.port — read that, then the env
  * override, then the default.
  */
-function readDashboardUrl(): string {
-  let port = process.env.PRISM_DASHBOARD_PORT || "3000";
-  try {
-    const recorded = fs.readFileSync(nodePath.join(os.homedir(), ".prism-mcp", "dashboard.port"), "utf8").trim();
-    if (/^\d{2,5}$/.test(recorded)) port = recorded;
-  } catch {
-    // port file absent — dashboard not started yet this boot; defaults hold
+async function readDashboardUrl(): Promise<string | null> {
+  // Precedence: explicit env override > recorded port file > default. The
+  // file is written by whatever dashboard ran last and persists across boots,
+  // so it must never outrank configuration the operator set for THIS process.
+  let port = (process.env.PRISM_DASHBOARD_PORT || "").trim();
+  if (!port) {
+    try {
+      const recorded = fs.readFileSync(nodePath.join(os.homedir(), ".prism-mcp", "dashboard.port"), "utf8").trim();
+      if (/^\d{2,5}$/.test(recorded)) port = recorded;
+    } catch {
+      // port file absent — dashboard not started yet this boot; default holds
+    }
   }
-  return `http://localhost:${port}`;
+  if (!port) port = "3000";
+  // The port file persists across boots and is never cleaned up, so it is
+  // evidence of a PREVIOUS dashboard, not a running one. Advertising a dead
+  // URL as the first-run headline action is worse than omitting it, so probe
+  // before promising. Bounded so startup latency cannot regress.
+  const listening = await new Promise<boolean>((resolveProbe) => {
+    const socket = new net.Socket();
+    const done = (value: boolean) => {
+      socket.destroy();
+      resolveProbe(value);
+    };
+    socket.setTimeout(250);
+    socket.once("connect", () => done(true));
+    socket.once("timeout", () => done(false));
+    socket.once("error", () => done(false));
+    socket.connect(Number(port), "127.0.0.1");
+  });
+  return listening ? `http://localhost:${port}` : null;
 }
 
 function capNativeStartupText(
@@ -1954,7 +1977,19 @@ export async function sessionBootstrapHandler(
   // with "Welcome back", three "Not loaded" rows, a warning, and three
   // statements of what it doesn't have — an all-absence payload with no next
   // step, no dashboard URL (stderr-only), and no path to the paid tier.
-  const isFirstRun = projects.length === 0 && !configuredGreetingName;
+  // First run must mean NEW, not merely unconfigured: a user with saved
+  // sessions who never set a name or projects would otherwise be told "first
+  // run detected" every single session. A durable marker is written after the
+  // first bootstrap, so this is decisive rather than heuristic.
+  const bootstrapSeen = (await getSetting("first_bootstrap_at", "")).trim();
+  const isFirstRun = projects.length === 0 && !configuredGreetingName && !bootstrapSeen;
+  if (!bootstrapSeen) {
+    try {
+      await setSetting("first_bootstrap_at", new Date().toISOString());
+    } catch {
+      // Marker is an optimization; a write failure must never block startup.
+    }
+  }
   const greeting = isFirstRun
     ? `👋 Welcome to Prism — first run detected. Let's get you productive in a few minutes.`
     : `👋 Welcome back, ${greetingName}. Prism is loading ${depth} context.`;
@@ -1962,7 +1997,10 @@ export async function sessionBootstrapHandler(
   const startupHeader = isFirstRun ? greeting : `${greeting}\n\n${identityBlock}`;
 
   if (projects.length === 0) {
-    const dashboardLine = `- 🎛️ **Dashboard:** ${readDashboardUrl()} — configure projects, identity, and context depth`;
+    const dashboardUrl = await readDashboardUrl();
+    const dashboardLine = dashboardUrl
+      ? `- 🎛️ **Dashboard:** ${dashboardUrl} — configure projects, identity, and context depth`
+      : `- 🎛️ **Dashboard:** not running — start Prism's dashboard to configure projects, identity, and context depth`;
     if (isFirstRun) {
       // Action-first instead of absence-first: every line is a capability or
       // a next step. The wizard exists and is well-built; route to it.

--- a/tests/tools/ledgerHandlers.test.ts
+++ b/tests/tools/ledgerHandlers.test.ts
@@ -1027,7 +1027,8 @@ describe("ledgerHandlers", () => {
 
   describe("sessionBootstrapHandler", () => {
     it("greets a first run with actions and the paid CTA, never with absence", async () => {
-      // First run = dashboard never touched: no agent identity, no projects.
+      // First run = dashboard never touched: no agent identity, no projects,
+      // no prior bootstrap marker.
       mockGetSetting.mockImplementation(async (key: string, fallback = "") => ({
         "skill_manifest:tier": "free",
         "skill_manifest:names": JSON.stringify(["prism-startup"]),
@@ -1038,7 +1039,7 @@ describe("ledgerHandlers", () => {
 
       expect(text).toContain("Welcome to Prism");
       expect(text).toContain("onboarding_wizard");
-      expect(text).toContain("http://localhost");
+      expect(text).toContain("Dashboard:");
       // The paid funnel's one guaranteed impression (2026-08-05 first-run
       // audit: the startup path referenced upgrade_url zero times).
       expect(text).toContain("https://synalux.ai/pricing");
@@ -1047,6 +1048,40 @@ describe("ledgerHandlers", () => {
       // followed by three "Not loaded" rows — an all-absence payload.
       expect(text).not.toContain("Welcome back");
       expect(text).not.toContain("Not loaded");
+    });
+
+    it("advertises the dashboard URL only when something is actually listening", async () => {
+      mockGetSetting.mockImplementation(async (key: string, fallback = "") => ({
+        "skill_manifest:tier": "free",
+        "skill_manifest:names": JSON.stringify(["prism-startup"]),
+      }[key] ?? fallback));
+      const originalPort = process.env.PRISM_DASHBOARD_PORT;
+
+      // Closed port: the port file persists across boots, so a URL must never
+      // be promised on that evidence alone.
+      process.env.PRISM_DASHBOARD_PORT = "1"; // reserved, never listening
+      try {
+        const dead = (await sessionBootstrapHandler({})).content[0].text as string;
+        expect(dead).toContain("Dashboard:** not running");
+        expect(dead).not.toContain("http://localhost");
+
+        // Live port: bind an ephemeral listener and confirm it is advertised.
+        const net = await import("node:net");
+        const server = net.createServer();
+        const port: number = await new Promise((done) => {
+          server.listen(0, "127.0.0.1", () => done((server.address() as any).port));
+        });
+        process.env.PRISM_DASHBOARD_PORT = String(port);
+        try {
+          const live = (await sessionBootstrapHandler({})).content[0].text as string;
+          expect(live).toContain(`http://localhost:${port}`);
+        } finally {
+          await new Promise((done) => server.close(() => done(null)));
+        }
+      } finally {
+        if (originalPort === undefined) delete process.env.PRISM_DASHBOARD_PORT;
+        else process.env.PRISM_DASHBOARD_PORT = originalPort;
+      }
     });
 
     it("keeps the returning-user shape when an identity exists without projects, adding the dashboard URL", async () => {
@@ -1061,7 +1096,9 @@ describe("ledgerHandlers", () => {
 
       expect(text).toContain("Welcome back, Dmitri");
       expect(text).toContain("Not loaded");
-      expect(text).toContain("http://localhost");
+      // Dashboard is surfaced either as a live URL or an honest "not running";
+      // the point is that it reaches stdout at all (it was stderr-only).
+      expect(text).toContain("Dashboard:");
       expect(result.structuredContent).not.toMatchObject({ first_run: true });
       // Paid tiers never see the upgrade line.
       expect(text).not.toContain("https://synalux.ai/pricing");


### PR DESCRIPTION
Self-review of everything merged this session. Seven confirmed defects, all in code I shipped today.

**Security / process**
1. **CLA allowlist was a name-string bypass** — `Synalux AI` let any external contributor skip the CLA on a public repo via `git config user.name`. Removed.
2. **Unpinned binary with publish credentials** — the registry job curled `releases/latest` while holding `id-token: write`. Pinned to v1.8.0 + verified sha256.
3. **Publish gate failed open** — `--manifest-only` was a phantom flag and the `||` fallback only compared top-level versions, so a stale `packages[].version` failed the real guard then passed the fallback.

**Correctness**
4. **`link(2)` silently disabled agent delivery** on filesystems without hard-link support — only `EEXIST` was caught, so exFAT/FAT32/SMB users got zero agents and a stderr line. Falls back to `rename(2)`.
5. **Agent entitlement gap** — the failed-sync catch path enforced skills only, leaving paid agent definitions on disk after a downgrade whose DB apply threw.
6. **Dead-URL CTA** — the dashboard port file persists across boots; now probed and reported honestly, and an explicit `PRISM_DASHBOARD_PORT` no longer loses to the stale file.
7. **First-run false positive** — gated on a durable marker instead of "unconfigured".

**Test integrity:** the dashboard assertion passed only because a local process held :3000 and would have failed in CI. Both branches now run deterministically against a bound ephemeral listener and a closed port.

Full suite 3776 passed, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)