### PR TITLE
release: 20.7.0 — analytics leak fix, dashboard identity probe, published-version guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-mcp-server",
-  "version": "20.6.0",
+  "version": "20.7.0",
   "mcpName": "io.github.dcostenco/prism-coder",
   "description": "Prism Coder \u2014 Cognitive memory + tool-calling intelligence for AI agents. Mind Palace persistent memory (BFCL Gold Certified, 100% Tool-Call Accuracy, 114 Agent Skills, PHI Guard, Tier Enforcement, Prompt-Based Skill Routing, Zero-Search HDC/HRR retrieval, HRR Semantic Drift Detection across BCBA/Coding/AAC domains, HIPAA-hardened local or subscription-gated Synalux storage, SLERP-optimized GRPO alignment) plus the prism-coder 1.7B\u201332B open-weights LLM fleet.",
   "module": "index.ts",

--- a/scripts/check-publish-clean.mjs
+++ b/scripts/check-publish-clean.mjs
@@ -73,6 +73,16 @@ export function publishedVersionConflict(name, version, lookup) {
 }
 
 function npmLatestVersion(name) {
+  // Test seam. Without it this check's own tests assert against the LIVE
+  // registry, so they encode whatever is published at the moment they were
+  // written — and publishing 20.7.0 immediately falsified a test that had
+  // hard-coded 20.6.0 as "already published". A guard whose tests break every
+  // time you release is worse than no tests.
+  const override = process.env.PRISM_GUARD_PUBLISHED_VERSION;
+  if (override !== undefined) {
+    if (override === "") throw new Error("simulated: package not published");
+    return override;
+  }
   return execFileSync("npm", ["view", name, "version"], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "ignore"],

--- a/scripts/check-publish-clean.mjs
+++ b/scripts/check-publish-clean.mjs
@@ -47,6 +47,39 @@ function checkServerManifest(repoRoot) {
   return serverManifestVersionMismatches(JSON.parse(rawPackage), JSON.parse(rawServer));
 }
 
+/**
+ * Refuse a version that npm already serves.
+ *
+ * Why (2026-08-05): the manifest guard above proves server.json and
+ * package.json AGREE — it says nothing about whether the version ADVANCED.
+ * So `main` accumulated a session's worth of shipped work while both files
+ * sat at 20.6.0, agreeing with each other and with npm, and disagreeing with
+ * reality. The publish ran the full build and pack before npm rejected it
+ * with "You cannot publish over the previously published versions".
+ *
+ * Fails OPEN on network trouble or an unpublished package: a first release
+ * and an offline release must both still work. Only a definite match blocks.
+ */
+export function publishedVersionConflict(name, version, lookup) {
+  let published;
+  try {
+    published = lookup(name);
+  } catch {
+    return null; // never published, offline, or registry unreachable
+  }
+  if (!published || published !== version) return null;
+  return `${name}@${version} is already published. Bump the version in ` +
+    `package.json AND server.json (the registry listing follows package.json).`;
+}
+
+function npmLatestVersion(name) {
+  return execFileSync("npm", ["view", name, "version"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 15_000,
+  }).trim();
+}
+
 function workingTreeStatus(repoRoot) {
   return execFileSync(
     "git",
@@ -96,5 +129,29 @@ if (IS_MAIN) {
     const message = error instanceof Error ? error.message : String(error);
     console.error(`npm publish blocked: unable to verify server.json: ${message}`);
     process.exitCode = 1;
+  }
+
+  try {
+    let raw;
+    try {
+      raw = readFileSync(join(process.cwd(), "package.json"), "utf8");
+    } catch (error) {
+      // No package.json means nothing to publish (and is the shape of this
+      // guard's own fixtures). Stay silent — a stderr warning here would make
+      // the reproducibility test, which asserts empty stderr, fail.
+      if (error && error.code === "ENOENT") raw = null;
+      else throw error;
+    }
+    if (raw) {
+      const pkg = JSON.parse(raw);
+      const conflict = publishedVersionConflict(pkg.name, pkg.version, npmLatestVersion);
+      if (conflict) {
+        console.error(`npm publish blocked: ${conflict}`);
+        process.exitCode = 1;
+      }
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`npm publish: skipped the published-version check (${message})`);
   }
 }

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/dcostenco/prism-coder",
     "source": "github"
   },
-  "version": "20.6.0",
+  "version": "20.7.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "prism-mcp-server",
-      "version": "20.6.0",
+      "version": "20.7.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/tools/ledgerHandlers.ts
+++ b/src/tools/ledgerHandlers.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as nodePath from "node:path";
 import * as os from "node:os";
-import * as net from "node:net";
+import * as http from "node:http";
 import { randomUUID } from "node:crypto";
 import { redactSettings, toMarkdown } from "./commonHelpers.js";
 import { scanAndRedactPHI } from "../utils/phiGuard.js";
@@ -436,21 +436,25 @@ async function readDashboardUrl(): Promise<string | null> {
   if (!port) port = "3000";
   // The port file persists across boots and is never cleaned up, so it is
   // evidence of a PREVIOUS dashboard, not a running one. Advertising a dead
-  // URL as the first-run headline action is worse than omitting it, so probe
-  // before promising. Bounded so startup latency cannot regress.
-  const listening = await new Promise<boolean>((resolveProbe) => {
-    const socket = new net.Socket();
-    const done = (value: boolean) => {
-      socket.destroy();
-      resolveProbe(value);
-    };
-    socket.setTimeout(250);
-    socket.once("connect", () => done(true));
-    socket.once("timeout", () => done(false));
-    socket.once("error", () => done(false));
-    socket.connect(Number(port), "127.0.0.1");
+  // URL as the first-run headline action is worse than omitting it.
+  //
+  // A TCP connect is NOT sufficient: it proves something is listening, not
+  // that it is Prism. The default is 3000 — the single most commonly occupied
+  // port on a developer machine — so a bare liveness check would confidently
+  // point a first-run user at their own dev server. Hit the dashboard's
+  // /api/health instead, so identity is verified rather than assumed.
+  const healthy = await new Promise<boolean>((resolveProbe) => {
+    const request = http.get(
+      { host: "127.0.0.1", port: Number(port), path: "/api/health", timeout: 300 },
+      (response) => {
+        response.resume(); // drain so the socket can close
+        resolveProbe(response.statusCode === 200);
+      },
+    );
+    request.once("timeout", () => { request.destroy(); resolveProbe(false); });
+    request.once("error", () => resolveProbe(false));
   });
-  return listening ? `http://localhost:${port}` : null;
+  return healthy ? `http://localhost:${port}` : null;
 }
 
 function capNativeStartupText(

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -91,6 +91,15 @@ async function ensureTable(): Promise<void> {
 
 /** Reset DB connection and in-memory buffer (for tests). */
 export function _resetDb(): void {
+    // Close before dropping the reference. Nulling alone leaks the underlying
+    // sqlite handle: harmless on POSIX (unlink works on open files), but on
+    // Windows the file stays locked, so a suite that resets between cases
+    // accumulates locks on the analytics DB and cannot clean up its temp dir.
+    try {
+        _db?.close();
+    } catch {
+        // A close failure must never break a test reset.
+    }
     _db = null;
     _tableReady = false;
     BUFFER.length = 0;

--- a/tests/publish-clean-guard.test.ts
+++ b/tests/publish-clean-guard.test.ts
@@ -103,6 +103,14 @@ describe("published-version conflict guard", () => {
     //
     // Driven through the SUBPROCESS, not import(): importing this .mjs under
     // vitest fails on Windows, while spawning it is already proven here.
+    function runGuardWithPublished(repo: string, published: string) {
+        return spawnSync(process.execPath, [SCRIPT], {
+            cwd: repo,
+            encoding: "utf8",
+            env: { ...process.env, PRISM_GUARD_PUBLISHED_VERSION: published },
+        });
+    }
+
     function repoWithPackage(name: string, version: string): string {
         const repo = createCommittedRepo();
         writeFileSync(resolve(repo, "package.json"), JSON.stringify({ name, version }, null, 2));
@@ -112,22 +120,23 @@ describe("published-version conflict guard", () => {
     }
 
     it("blocks a version npm already serves", () => {
-        // prism-mcp-server@20.6.0 is published; re-publishing it must fail.
-        const result = runGuard(repoWithPackage("prism-mcp-server", "20.6.0"));
+        // Pinned via the seam, NOT the live registry: hard-coding a real
+        // published version made this test fail the moment 20.7.0 shipped.
+        const result = runGuardWithPublished(repoWithPackage("pkg", "20.6.0"), "20.6.0");
         expect(result.status).toBe(1);
         expect(result.stderr).toContain("already published");
         expect(result.stderr).toContain("server.json");
     });
 
     it("allows a version that advances past the published one", () => {
-        const result = runGuard(repoWithPackage("prism-mcp-server", "999.0.0"));
+        const result = runGuardWithPublished(repoWithPackage("pkg", "20.7.0"), "20.6.0");
         expect(result.stderr).not.toContain("already published");
         expect(result.status).toBe(0);
     });
 
     it("fails OPEN for a package the registry does not know", () => {
         // A first release must still work, so an unknown package cannot block.
-        const result = runGuard(repoWithPackage("prism-guard-fixture-does-not-exist-xyz", "1.0.0"));
+        const result = runGuardWithPublished(repoWithPackage("pkg", "1.0.0"), "");
         expect(result.stderr).not.toContain("already published");
         expect(result.status).toBe(0);
     });

--- a/tests/publish-clean-guard.test.ts
+++ b/tests/publish-clean-guard.test.ts
@@ -93,3 +93,29 @@ describe("private identifiers must not appear in tracked files", () => {
     expect(hits, `private identifier leaked into: ${hits.join(", ")}`).toEqual([]);
   });
 });
+
+describe("published-version conflict guard", () => {
+    // The manifest guard proves server.json and package.json AGREE. It says
+    // nothing about whether the version ADVANCED — so main accumulated a
+    // session of shipped work while both files sat at 20.6.0, agreeing with
+    // each other and with npm, and disagreeing with reality. The publish ran
+    // a full build and pack before npm rejected it.
+    it("blocks a version npm already serves", async () => {
+        const { publishedVersionConflict } = await import("../scripts/check-publish-clean.mjs");
+        const conflict = publishedVersionConflict("pkg", "20.6.0", () => "20.6.0");
+        expect(conflict).toContain("already published");
+        expect(conflict).toContain("server.json");
+    });
+
+    it("allows a version that advances past the published one", async () => {
+        const { publishedVersionConflict } = await import("../scripts/check-publish-clean.mjs");
+        expect(publishedVersionConflict("pkg", "20.7.0", () => "20.6.0")).toBeNull();
+    });
+
+    it("fails OPEN when the registry is unreachable or the package is new", async () => {
+        const { publishedVersionConflict } = await import("../scripts/check-publish-clean.mjs");
+        // A first release and an offline release must both still work.
+        expect(publishedVersionConflict("pkg", "1.0.0", () => { throw new Error("ENOTFOUND"); })).toBeNull();
+        expect(publishedVersionConflict("pkg", "1.0.0", () => "")).toBeNull();
+    });
+});

--- a/tests/publish-clean-guard.test.ts
+++ b/tests/publish-clean-guard.test.ts
@@ -6,10 +6,15 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 
 const SCRIPT = resolve(process.cwd(), "scripts/check-publish-clean.mjs");
 const tempRepos: string[] = [];
+// Windows: import() of a raw path like C:\... treats the drive letter as a
+// protocol and throws "SyntaxError: Invalid or unexpected token". A file://
+// URL is the portable form.
+const GUARD_MODULE = pathToFileURL(SCRIPT).href;
 
 function createCommittedRepo(): string {
   const repo = mkdtempSync(resolve(tmpdir(), "prism-publish-guard-"));
@@ -101,19 +106,19 @@ describe("published-version conflict guard", () => {
     // each other and with npm, and disagreeing with reality. The publish ran
     // a full build and pack before npm rejected it.
     it("blocks a version npm already serves", async () => {
-        const { publishedVersionConflict } = await import("../scripts/check-publish-clean.mjs");
+        const { publishedVersionConflict } = await import(GUARD_MODULE);
         const conflict = publishedVersionConflict("pkg", "20.6.0", () => "20.6.0");
         expect(conflict).toContain("already published");
         expect(conflict).toContain("server.json");
     });
 
     it("allows a version that advances past the published one", async () => {
-        const { publishedVersionConflict } = await import("../scripts/check-publish-clean.mjs");
+        const { publishedVersionConflict } = await import(GUARD_MODULE);
         expect(publishedVersionConflict("pkg", "20.7.0", () => "20.6.0")).toBeNull();
     });
 
     it("fails OPEN when the registry is unreachable or the package is new", async () => {
-        const { publishedVersionConflict } = await import("../scripts/check-publish-clean.mjs");
+        const { publishedVersionConflict } = await import(GUARD_MODULE);
         // A first release and an offline release must both still work.
         expect(publishedVersionConflict("pkg", "1.0.0", () => { throw new Error("ENOTFOUND"); })).toBeNull();
         expect(publishedVersionConflict("pkg", "1.0.0", () => "")).toBeNull();

--- a/tests/publish-clean-guard.test.ts
+++ b/tests/publish-clean-guard.test.ts
@@ -6,15 +6,10 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
-import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 
 const SCRIPT = resolve(process.cwd(), "scripts/check-publish-clean.mjs");
 const tempRepos: string[] = [];
-// Windows: import() of a raw path like C:\... treats the drive letter as a
-// protocol and throws "SyntaxError: Invalid or unexpected token". A file://
-// URL is the portable form.
-const GUARD_MODULE = pathToFileURL(SCRIPT).href;
 
 function createCommittedRepo(): string {
   const repo = mkdtempSync(resolve(tmpdir(), "prism-publish-guard-"));
@@ -103,24 +98,37 @@ describe("published-version conflict guard", () => {
     // The manifest guard proves server.json and package.json AGREE. It says
     // nothing about whether the version ADVANCED — so main accumulated a
     // session of shipped work while both files sat at 20.6.0, agreeing with
-    // each other and with npm, and disagreeing with reality. The publish ran
-    // a full build and pack before npm rejected it.
-    it("blocks a version npm already serves", async () => {
-        const { publishedVersionConflict } = await import(GUARD_MODULE);
-        const conflict = publishedVersionConflict("pkg", "20.6.0", () => "20.6.0");
-        expect(conflict).toContain("already published");
-        expect(conflict).toContain("server.json");
+    // each other and with npm, and disagreeing with reality. npm only
+    // rejected it after a full build and pack.
+    //
+    // Driven through the SUBPROCESS, not import(): importing this .mjs under
+    // vitest fails on Windows, while spawning it is already proven here.
+    function repoWithPackage(name: string, version: string): string {
+        const repo = createCommittedRepo();
+        writeFileSync(resolve(repo, "package.json"), JSON.stringify({ name, version }, null, 2));
+        execFileSync("git", ["add", "package.json"], { cwd: repo });
+        execFileSync("git", ["commit", "--quiet", "-m", "package"], { cwd: repo });
+        return repo;
+    }
+
+    it("blocks a version npm already serves", () => {
+        // prism-mcp-server@20.6.0 is published; re-publishing it must fail.
+        const result = runGuard(repoWithPackage("prism-mcp-server", "20.6.0"));
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain("already published");
+        expect(result.stderr).toContain("server.json");
     });
 
-    it("allows a version that advances past the published one", async () => {
-        const { publishedVersionConflict } = await import(GUARD_MODULE);
-        expect(publishedVersionConflict("pkg", "20.7.0", () => "20.6.0")).toBeNull();
+    it("allows a version that advances past the published one", () => {
+        const result = runGuard(repoWithPackage("prism-mcp-server", "999.0.0"));
+        expect(result.stderr).not.toContain("already published");
+        expect(result.status).toBe(0);
     });
 
-    it("fails OPEN when the registry is unreachable or the package is new", async () => {
-        const { publishedVersionConflict } = await import(GUARD_MODULE);
-        // A first release and an offline release must both still work.
-        expect(publishedVersionConflict("pkg", "1.0.0", () => { throw new Error("ENOTFOUND"); })).toBeNull();
-        expect(publishedVersionConflict("pkg", "1.0.0", () => "")).toBeNull();
+    it("fails OPEN for a package the registry does not know", () => {
+        // A first release must still work, so an unknown package cannot block.
+        const result = runGuard(repoWithPackage("prism-guard-fixture-does-not-exist-xyz", "1.0.0"));
+        expect(result.stderr).not.toContain("already published");
+        expect(result.status).toBe(0);
     });
 });

--- a/tests/tools/ledgerHandlers.test.ts
+++ b/tests/tools/ledgerHandlers.test.ts
@@ -21,7 +21,7 @@
  * ======================================================================
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from "vitest";
 import * as fs from "node:fs";
 import * as nodePath from "node:path";
 import * as os from "node:os";
@@ -1026,6 +1026,18 @@ describe("ledgerHandlers", () => {
   });
 
   describe("sessionBootstrapHandler", () => {
+    // Pin every bootstrap test to a dead port by default. Without this the
+    // dashboard probe reaches whatever the developer happens to be running
+    // locally, so results differ between a laptop and CI — the exact
+    // environment coupling that made an earlier assertion pass here and fail
+    // in CI. Tests that care about the probe set this explicitly.
+    const savedDashboardPort = process.env.PRISM_DASHBOARD_PORT;
+    beforeEach(() => { process.env.PRISM_DASHBOARD_PORT = "1"; });
+    afterAll(() => {
+      if (savedDashboardPort === undefined) delete process.env.PRISM_DASHBOARD_PORT;
+      else process.env.PRISM_DASHBOARD_PORT = savedDashboardPort;
+    });
+
     it("greets a first run with actions and the paid CTA, never with absence", async () => {
       // First run = dashboard never touched: no agent identity, no projects,
       // no prior bootstrap marker.
@@ -1065,18 +1077,39 @@ describe("ledgerHandlers", () => {
         expect(dead).toContain("Dashboard:** not running");
         expect(dead).not.toContain("http://localhost");
 
-        // Live port: bind an ephemeral listener and confirm it is advertised.
-        const net = await import("node:net");
-        const server = net.createServer();
-        const port: number = await new Promise((done) => {
-          server.listen(0, "127.0.0.1", () => done((server.address() as any).port));
+        const http = await import("node:http");
+        const serve = async (handler: http.RequestListener) => {
+          const server = http.createServer(handler);
+          const port: number = await new Promise((done) => {
+            server.listen(0, "127.0.0.1", () => done((server.address() as any).port));
+          });
+          return { server, port };
+        };
+
+        // A FOREIGN listener must be rejected. The default port is 3000 — the
+        // most commonly occupied port on a developer machine — so a bare
+        // liveness check would point a first-run user at their own dev server.
+        const foreign = await serve((_req, res) => { res.statusCode = 404; res.end("not prism"); });
+        process.env.PRISM_DASHBOARD_PORT = String(foreign.port);
+        try {
+          const wrong = (await sessionBootstrapHandler({})).content[0].text as string;
+          expect(wrong).toContain("Dashboard:** not running");
+          expect(wrong).not.toContain(`http://localhost:${foreign.port}`);
+        } finally {
+          await new Promise((done) => foreign.server.close(() => done(null)));
+        }
+
+        // A real dashboard answers /api/health with 200 and IS advertised.
+        const real = await serve((req, res) => {
+          if (req.url === "/api/health") { res.statusCode = 200; res.end("{}"); return; }
+          res.statusCode = 404; res.end();
         });
-        process.env.PRISM_DASHBOARD_PORT = String(port);
+        process.env.PRISM_DASHBOARD_PORT = String(real.port);
         try {
           const live = (await sessionBootstrapHandler({})).content[0].text as string;
-          expect(live).toContain(`http://localhost:${port}`);
+          expect(live).toContain(`http://localhost:${real.port}`);
         } finally {
-          await new Promise((done) => server.close(() => done(null)));
+          await new Promise((done) => real.server.close(() => done(null)));
         }
       } finally {
         if (originalPort === undefined) delete process.env.PRISM_DASHBOARD_PORT;


### PR DESCRIPTION
`_resetDb()` set `_db = null` without calling `close()`, leaking the underlying sqlite handle on every reset.

Invisible on POSIX (unlink works on files with open descriptors) but on Windows the file stays locked, so a suite resetting between cases accumulates locks on the analytics DB and cannot clean up its directory.

Found while investigating the Windows EBUSY teardown failure. Being precise: this is **not** that failure's cause — analytics uses `~/.prism-mcp/data.db`, not the test's `isolated.db` — but it is the same class of defect and real on its own.

Verified with `scripts/local-ci.sh` (audit, leak guard, build, unit tests, process-level CLI): all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)