### PR TITLE
fix(registry): give the publish workflow a manifest-only guard mode

### DIFF
--- a/.github/workflows/registry-publish.yml
+++ b/.github/workflows/registry-publish.yml
@@ -23,7 +23,7 @@ jobs:
       # stale packages[].version failed the real guard and then PASSED the
       # fallback — a publish gate that fails open is not a gate.
       - name: Guard — manifest must match package.json
-        run: node scripts/check-publish-clean.mjs
+        run: node scripts/check-publish-clean.mjs --manifest-only
       - name: Install mcp-publisher
         env:
           MCP_PUBLISHER_VERSION: v1.8.0

--- a/scripts/check-publish-clean.mjs
+++ b/scripts/check-publish-clean.mjs
@@ -141,7 +141,16 @@ if (IS_MAIN) {
     process.exitCode = 1;
   }
 
+  // --manifest-only: verify the manifests agree, but SKIP the
+  // already-published check. The registry publish workflow runs AFTER npm
+  // publish, so "this version is on npm" is its correct precondition, not an
+  // error — without this flag the guard blocks the very republish it exists
+  // to protect (it did, on 20.7.0). npm publish itself passes no flag and
+  // still gets the full gate.
+  const manifestOnly = process.argv.includes("--manifest-only");
+
   try {
+    if (manifestOnly) throw { code: "SKIP" };
     let raw;
     try {
       raw = readFileSync(join(process.cwd(), "package.json"), "utf8");
@@ -161,7 +170,11 @@ if (IS_MAIN) {
       }
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(`npm publish: skipped the published-version check (${message})`);
+    if (error?.code === "SKIP") {
+      console.log("manifest-only mode: skipping the published-version check.");
+    } else {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`npm publish: skipped the published-version check (${message})`);
+    }
   }
 }

--- a/tests/publish-clean-guard.test.ts
+++ b/tests/publish-clean-guard.test.ts
@@ -134,6 +134,24 @@ describe("published-version conflict guard", () => {
         expect(result.status).toBe(0);
     });
 
+    it("--manifest-only skips the published check, because the registry republish runs AFTER npm publish", () => {
+        // Without this the guard blocks the very republish it exists to
+        // protect: the registry workflow runs post-publish, so "this version
+        // is on npm" is its correct precondition. Observed on 20.7.0.
+        const repo = repoWithPackage("pkg", "20.6.0");
+        const full = runGuardWithPublished(repo, "20.6.0");
+        expect(full.status).toBe(1);
+        expect(full.stderr).toContain("already published");
+
+        const scoped = spawnSync(process.execPath, [SCRIPT, "--manifest-only"], {
+            cwd: repo,
+            encoding: "utf8",
+            env: { ...process.env, PRISM_GUARD_PUBLISHED_VERSION: "20.6.0" },
+        });
+        expect(scoped.status).toBe(0);
+        expect(scoped.stderr).not.toContain("already published");
+    });
+
     it("fails OPEN for a package the registry does not know", () => {
         // A first release must still work, so an unknown package cannot block.
         const result = runGuardWithPublished(repoWithPackage("pkg", "1.0.0"), "");


### PR DESCRIPTION
The 20.7.0 registry republish **failed**, blocked by this session's own published-version guard:

```
npm publish blocked: prism-mcp-server@20.7.0 is already published.
```

The registry workflow runs **after** npm publish, so "this version is on npm" is its correct precondition, not an error. The guard is a `prepublishOnly` gate that was reused where its central assumption is inverted.

`--manifest-only` keeps what matters there (clean tree, `server.json` agrees with `package.json`) and skips the npm lookup. `npm publish` passes no flag and still gets the full gate.

Worth noting: an earlier commit **removed** a phantom `--manifest-only` that the script never parsed and whose `||` fallback silently failed open. This implements it for real, with a test pinning both modes so it can't decay back into a no-op.

Local CI green (11 guard tests). Replaces #111, which conflicted after #110's squash merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)