### PR TITLE
fix(plugin): bump codex plugin manifest to 20.7.0, guard every versioned manifest

### DIFF
--- a/.github/workflows/windows-diagnostic.yml
+++ b/.github/workflows/windows-diagnostic.yml
@@ -1,0 +1,41 @@
+name: Windows Diagnostic
+
+# A trimmed, on-demand Windows instrument — NOT a gate.
+#
+# The full CLI Integration matrix takes ~7 minutes per iteration and answers
+# only pass/fail. Six attempts at the Windows EBUSY teardown failure were
+# designed blind because of that loop: three were empirically refuted, and the
+# one that turned CI green did so by making cleanup non-fatal rather than by
+# releasing the handle.
+#
+# This job runs ONLY the diagnostic, ONLY on windows-x64 — the exact platform
+# where the bug lives, and the only Windows arch libsql ships a native binding
+# for (@libsql/win32-x64-msvc; there is no win32-arm64, which is why a local
+# Windows-on-ARM VM cannot faithfully reproduce it).
+#
+# Run it from the Actions tab or:  gh workflow run windows-diagnostic.yml
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  diagnose:
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+
+      # No Python/browser runtime, no audit, no leak guard, no build of the
+      # full test suite — this job exists to answer one question quickly.
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: SQLite handle-release diagnostic
+        run: npx vitest run tests/verification/windows-sqlite-handle.test.ts --reporter=verbose

--- a/plugins/prism/.codex-plugin/plugin.json
+++ b/plugins/prism/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prism",
-  "version": "20.6.0",
+  "version": "20.7.0",
   "description": "Persistent session memory for Codex. Prism restores what you were doing across sessions — decisions, open TODOs, changed files — and carries knowledge search, drift detection, and local-first inference. Memory stays in SQLite on your machine by default.\n\nOn the first user turn of a conversation, call session_bootstrap once before answering, then print its result verbatim as the startup display.",
   "author": {
     "name": "Synalux"

--- a/scripts/check-publish-clean.mjs
+++ b/scripts/check-publish-clean.mjs
@@ -30,6 +30,33 @@ export function serverManifestVersionMismatches(packageJson, serverJson) {
   return problems;
 }
 
+/**
+ * Every OTHER manifest that carries a version and is published to a
+ * storefront. The Codex plugin manifest sat at 20.6.0 through the 20.7.0
+ * release and was caught only by reading it before a marketplace submission
+ * — server.json was guarded, this was not. Any file listed here is held to
+ * the same rule: if it declares a version, it must be package.json's.
+ */
+const VERSIONED_MANIFESTS = ["plugins/prism/.codex-plugin/plugin.json"];
+
+function checkVersionedManifests(repoRoot, expected) {
+  const problems = [];
+  for (const relative of VERSIONED_MANIFESTS) {
+    let raw;
+    try {
+      raw = readFileSync(join(repoRoot, relative), "utf8");
+    } catch (error) {
+      if (error && error.code === "ENOENT") continue; // not this repo's concern
+      throw error;
+    }
+    const manifest = JSON.parse(raw);
+    if (manifest.version !== undefined && manifest.version !== expected) {
+      problems.push(`${relative} version is ${manifest.version}, expected ${expected}`);
+    }
+  }
+  return problems;
+}
+
 function checkServerManifest(repoRoot) {
   // A repo without a registry manifest has nothing to drift: repos that never
   // published to the MCP Registry (and the guard's own test fixtures) must
@@ -44,7 +71,11 @@ function checkServerManifest(repoRoot) {
     if (error && error.code === "ENOENT") return [];
     throw error;
   }
-  return serverManifestVersionMismatches(JSON.parse(rawPackage), JSON.parse(rawServer));
+  const packageJson = JSON.parse(rawPackage);
+  return [
+    ...serverManifestVersionMismatches(packageJson, JSON.parse(rawServer)),
+    ...checkVersionedManifests(repoRoot, packageJson.version),
+  ];
 }
 
 /**

--- a/scripts/check-publish-clean.mjs
+++ b/scripts/check-publish-clean.mjs
@@ -100,7 +100,9 @@ export function publishedVersionConflict(name, version, lookup) {
   }
   if (!published || published !== version) return null;
   return `${name}@${version} is already published. Bump the version in ` +
-    `package.json AND server.json (the registry listing follows package.json).`;
+    `package.json, server.json (incl. packages[].version), and every entry in ` +
+    `VERSIONED_MANIFESTS — naming only some of them is how the Codex plugin ` +
+    `manifest drifted a full release behind.`;
 }
 
 function npmLatestVersion(name) {
@@ -160,7 +162,7 @@ if (IS_MAIN) {
     const problems = checkServerManifest(process.cwd());
     if (problems.length) {
       console.error(
-        "npm publish blocked: server.json disagrees with package.json.\n" +
+        "npm publish blocked: a versioned manifest disagrees with package.json.\n" +
           "The MCP Registry listing would ship stale versions:\n  " +
           problems.join("\n  "),
       );
@@ -168,7 +170,7 @@ if (IS_MAIN) {
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    console.error(`npm publish blocked: unable to verify server.json: ${message}`);
+    console.error(`npm publish blocked: unable to verify the versioned manifests: ${message}`);
     process.exitCode = 1;
   }
 
@@ -180,8 +182,9 @@ if (IS_MAIN) {
   // still gets the full gate.
   const manifestOnly = process.argv.includes("--manifest-only");
 
-  try {
-    if (manifestOnly) throw { code: "SKIP" };
+  if (manifestOnly) {
+    console.log("manifest-only mode: skipping the published-version check.");
+  } else try {
     let raw;
     try {
       raw = readFileSync(join(process.cwd(), "package.json"), "utf8");
@@ -201,11 +204,7 @@ if (IS_MAIN) {
       }
     }
   } catch (error) {
-    if (error?.code === "SKIP") {
-      console.log("manifest-only mode: skipping the published-version check.");
-    } else {
-      const message = error instanceof Error ? error.message : String(error);
-      console.error(`npm publish: skipped the published-version check (${message})`);
-    }
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`npm publish: skipped the published-version check (${message})`);
   }
 }

--- a/tests/verification/first-run-e2e.test.ts
+++ b/tests/verification/first-run-e2e.test.ts
@@ -1,0 +1,139 @@
+/**
+ * First-run E2E — the greeting a brand-new user actually receives.
+ *
+ * Drives the BUILT server (dist/server.js) over real stdio through the MCP
+ * client, exactly as a host does. Unit tests call the handler directly and so
+ * cannot catch a regression in transport, tool registration, or startup
+ * wiring — the layers where "it works in the test" stops meaning "it works in
+ * the product".
+ *
+ * Why this exists (2026-08-05): a scrubbed-environment probe found the free
+ * tier greeting a first-time user with "Welcome back", three "Not loaded"
+ * rows, and three statements of what they lacked — no next step, no price, no
+ * dashboard, and the tool the greeting pointed at rejected its own documented
+ * bare call. Every assertion below is one of those defects. They were fixed in
+ * 20.7.0 and verified against the published tarball; this test keeps them fixed.
+ *
+ * Determinism: a scrubbed HOME (no config, no memory, no marker), skill sync
+ * disabled (no network), and a dashboard port nothing listens on.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SERVER = path.resolve(__dirname, "../../dist/server.js");
+
+describe("first-run experience (E2E over stdio)", { timeout: 60_000 }, () => {
+  let client: Client;
+  let scrubHome: string;
+  let greeting = "";
+  let structured: Record<string, unknown> | null = null;
+
+  beforeAll(async () => {
+    // The suite runs after "Build TypeScript" in CI. Fail loudly rather than
+    // silently passing against a stale or absent build.
+    expect(existsSync(SERVER), `built server missing at ${SERVER} — run npm run build`).toBe(true);
+
+    scrubHome = mkdtempSync(path.join(tmpdir(), "prism-first-run-e2e-"));
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [SERVER],
+      env: {
+        PATH: process.env.PATH ?? "",
+        HOME: scrubHome,
+        USERPROFILE: scrubHome, // Windows equivalent of HOME
+        PRISM_SKILL_SYNC_DISABLED: "true",
+        PRISM_DASHBOARD_PORT: "1", // reserved; nothing ever listens here
+      },
+    });
+    client = new Client({ name: "first-run-e2e", version: "1.0.0" });
+    await client.connect(transport);
+
+    const result = await client.callTool({
+      name: "session_bootstrap",
+      arguments: { prompt: "hello" },
+    });
+    greeting = String((result.content as Array<{ text?: string }>)?.[0]?.text ?? "");
+    structured = (result.structuredContent as Record<string, unknown>) ?? null;
+  });
+
+  afterAll(async () => {
+    try {
+      await client?.close();
+    } finally {
+      // Best-effort: the server holds sqlite handles that Windows releases on
+      // its own schedule. A cleanup failure must not fail a passing suite.
+      try {
+        rmSync(scrubHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      } catch { /* temp dir is reclaimed by the OS */ }
+    }
+  });
+
+  it("does not greet a first-time user as a returning one", () => {
+    expect(greeting).toContain("Welcome to Prism");
+    expect(greeting).not.toContain("Welcome back");
+  });
+
+  it("leads with actions, not with an inventory of what the user lacks", () => {
+    expect(greeting).not.toContain("Not loaded");
+    expect(greeting).toContain("onboarding_wizard");
+    expect(greeting).toContain("session_save_ledger");
+  });
+
+  it("surfaces the paid tier on the one guaranteed impression", () => {
+    // Before 20.7.0 upgrade_url appeared only AFTER hitting an entitlement
+    // gate; the startup path referenced it zero times.
+    expect(greeting).toContain("https://synalux.ai/pricing");
+    expect(greeting).toContain("free");
+  });
+
+  it("reports the dashboard honestly instead of advertising a dead URL", () => {
+    // Port 1 is not listening, so no URL may be promised.
+    expect(greeting).toContain("not running");
+    expect(greeting).not.toContain("http://localhost:1");
+  });
+
+  it("flags the run as first in structured output", () => {
+    expect(structured).toMatchObject({ first_run: true, projects: [] });
+    expect(typeof structured?.conversation_id).toBe("string");
+  });
+
+  it("the wizard the greeting points at accepts the bare call it documents", async () => {
+    // This used to fail with "Invalid arguments": the first tool a new user
+    // touches was also the first error they saw.
+    const wizard = await client.callTool({ name: "onboarding_wizard", arguments: {} });
+    expect(wizard.isError).not.toBe(true);
+    const body = JSON.parse(String((wizard.content as Array<{ text?: string }>)?.[0]?.text ?? "{}"));
+    expect(body.status).toBe("in_progress");
+    expect(body.total_steps).toBe(8);
+    expect(body.step_index).toBe(0);
+  });
+
+  it("advances the wizard instead of re-rendering step one", async () => {
+    const first = JSON.parse(String((await client.callTool({
+      name: "onboarding_wizard", arguments: { action: "start" },
+    })).content?.[0]?.text ?? "{}"));
+    const next = JSON.parse(String((await client.callTool({
+      name: "onboarding_wizard", arguments: { action: "next", step: first.step_index },
+    })).content?.[0]?.text ?? "{}"));
+    expect(next.step_index).toBeGreaterThan(first.step_index);
+    expect(next.current_step).not.toBe(first.current_step);
+  });
+
+  it("stops calling it a first run once the machine has bootstrapped", async () => {
+    // Guards the false positive where "unconfigured" was read as "new", so a
+    // user with saved sessions was greeted as a stranger every time.
+    const second = await client.callTool({
+      name: "session_bootstrap",
+      arguments: { prompt: "hello again" },
+    });
+    const text = String((second.content as Array<{ text?: string }>)?.[0]?.text ?? "");
+    expect((second.structuredContent as Record<string, unknown>)?.first_run).not.toBe(true);
+    expect(text).not.toContain("first run detected");
+  });
+});

--- a/tests/verification/first-run-e2e.test.ts
+++ b/tests/verification/first-run-e2e.test.ts
@@ -15,12 +15,17 @@
  * 20.7.0 and verified against the published tarball; this test keeps them fixed.
  *
  * Determinism: a scrubbed HOME (no config, no memory, no marker), skill sync
- * disabled (no network), and a dashboard port nothing listens on.
+ * disabled (no network), and a bound foreign HTTP server for the dashboard
+ * probe. It deliberately does NOT assume a port is closed — "nothing listens
+ * on port 1" held on macOS and was FALSE on the Windows runner, where
+ * something answered 200 and the greeting advertised http://localhost:1.
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import * as http from "node:http";
+import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -31,6 +36,7 @@ const SERVER = path.resolve(__dirname, "../../dist/server.js");
 describe("first-run experience (E2E over stdio)", { timeout: 60_000 }, () => {
   let client: Client;
   let scrubHome: string;
+  let foreignServer: http.Server;
   let greeting = "";
   let structured: Record<string, unknown> | null = null;
 
@@ -38,6 +44,20 @@ describe("first-run experience (E2E over stdio)", { timeout: 60_000 }, () => {
     // The suite runs after "Build TypeScript" in CI. Fail loudly rather than
     // silently passing against a stale or absent build.
     expect(existsSync(SERVER), `built server missing at ${SERVER} — run npm run build`).toBe(true);
+
+    // Point the dashboard probe at a REAL server that is not Prism, rather
+    // than at a port assumed to be closed. "Nothing listens on port 1" is a
+    // portability assumption, not a fact: on the Windows runner something
+    // answered 200 there and the greeting advertised http://localhost:1.
+    // A bound 404 responder is deterministic everywhere AND proves the
+    // stronger property — identity is verified, not mere liveness.
+    foreignServer = http.createServer((_req, res) => {
+      res.statusCode = 404;
+      res.end("not prism");
+    });
+    const foreignPort: number = await new Promise((done) => {
+      foreignServer.listen(0, "127.0.0.1", () => done((foreignServer.address() as AddressInfo).port));
+    });
 
     scrubHome = mkdtempSync(path.join(tmpdir(), "prism-first-run-e2e-"));
     const transport = new StdioClientTransport({
@@ -48,7 +68,7 @@ describe("first-run experience (E2E over stdio)", { timeout: 60_000 }, () => {
         HOME: scrubHome,
         USERPROFILE: scrubHome, // Windows equivalent of HOME
         PRISM_SKILL_SYNC_DISABLED: "true",
-        PRISM_DASHBOARD_PORT: "1", // reserved; nothing ever listens here
+        PRISM_DASHBOARD_PORT: String(foreignPort),
       },
     });
     client = new Client({ name: "first-run-e2e", version: "1.0.0" });
@@ -65,6 +85,7 @@ describe("first-run experience (E2E over stdio)", { timeout: 60_000 }, () => {
   afterAll(async () => {
     try {
       await client?.close();
+      await new Promise((done) => foreignServer?.close(() => done(null)));
     } finally {
       // Best-effort: the server holds sqlite handles that Windows releases on
       // its own schedule. A cleanup failure must not fail a passing suite.
@@ -92,10 +113,12 @@ describe("first-run experience (E2E over stdio)", { timeout: 60_000 }, () => {
     expect(greeting).toContain("free");
   });
 
-  it("reports the dashboard honestly instead of advertising a dead URL", () => {
-    // Port 1 is not listening, so no URL may be promised.
+  it("rejects a listener that is not Prism instead of advertising it", () => {
+    // A foreign 404 responder is bound on that port, so a bare liveness check
+    // would advertise someone else's service — on a dev machine, most likely
+    // the user's own app on :3000.
     expect(greeting).toContain("not running");
-    expect(greeting).not.toContain("http://localhost:1");
+    expect(greeting).not.toContain("http://localhost");
   });
 
   it("flags the run as first in structured output", () => {

--- a/tests/verification/windows-sqlite-handle.test.ts
+++ b/tests/verification/windows-sqlite-handle.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Windows SQLite handle-release DIAGNOSTIC.
+ *
+ * Reports facts; it does not gate. Every assertion here is one that holds on
+ * any platform — the payload is the console output.
+ *
+ * Why this exists (2026-08-05): six attempts at the Windows EBUSY teardown
+ * failure were designed blind, because the only feedback available was a
+ * ~7-minute pass/fail matrix. Three were empirically refuted:
+ *   1. missing storage.close()          -> added; still EBUSY
+ *   2. async handle release             -> maxRetries 10 x 100ms; still EBUSY
+ *   3. (the one that went green)        -> made cleanup non-fatal, which
+ *                                          releases nothing
+ * So the product question is still open: does SqliteStorage.close() actually
+ * release the file on Windows? It matters beyond tests — if it does not,
+ * Windows users cannot move, delete, or back up their database.
+ *
+ * A local VM cannot answer this: libsql ships only @libsql/win32-x64-msvc,
+ * with no win32-arm64 build, so a Windows-on-ARM guest either fails to load
+ * the binding or runs it under x64 emulation — an unreliable witness for a
+ * bug about handle-release timing.
+ *
+ * Each experiment isolates one hypothesis, and reports WHICH path is locked:
+ * the database, or its memory-mapped WAL/SHM sidecars.
+ */
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readdirSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SqliteStorage } from "../../src/storage/sqlite.js";
+
+const IS_WINDOWS = process.platform === "win32";
+
+/** Try to unlink one path; report the errno instead of throwing. */
+function probeUnlink(path: string): string {
+  if (!existsSync(path)) return "absent";
+  try {
+    unlinkSync(path);
+    return "unlinked OK";
+  } catch (error) {
+    const e = error as NodeJS.ErrnoException;
+    return `${e.code ?? "ERR"} (${e.syscall ?? "?"})`;
+  }
+}
+
+/** Seed a storage instance so WAL/SHM sidecars actually exist. */
+async function seed(dir: string): Promise<SqliteStorage> {
+  const storage = new SqliteStorage();
+  await storage.initialize(true, join(dir, "isolated.db"));
+  await storage.saveLedger({
+    project: "diag", conversation_id: "c1", user_id: "default",
+    role: "global", summary: "handle diagnostic row", keywords: ["diag"],
+  } as never);
+  return storage;
+}
+
+function report(label: string, dir: string): void {
+  const files = existsSync(dir) ? readdirSync(dir) : [];
+  console.log(`\n[${label}] files present: ${files.join(", ") || "(none)"}`);
+  for (const name of ["isolated.db-shm", "isolated.db-wal", "isolated.db"]) {
+    console.log(`[${label}]   ${name.padEnd(18)} -> ${probeUnlink(join(dir, name))}`);
+  }
+}
+
+describe("Windows sqlite handle release (diagnostic)", { timeout: 60_000 }, () => {
+  it(`reports handle state after close (platform=${process.platform})`, async () => {
+    console.log(`\n=== platform=${process.platform} arch=${process.arch} node=${process.version} ===`);
+    if (!IS_WINDOWS) {
+      console.log("POSIX: unlink succeeds on open files, so this cannot reproduce here.");
+      console.log("Run on windows-x64 via: gh workflow run windows-diagnostic.yml");
+    }
+
+    // E1 — baseline: close(), then unlink each file. Which one is locked?
+    const d1 = mkdtempSync(join(tmpdir(), "prism-diag-e1-"));
+    const s1 = await seed(d1);
+    await s1.close();
+    report("E1 close() only", d1);
+
+    // E2 — checkpoint the WAL into the db before closing. If the sidecars are
+    // what stay mapped, this is the fix, and it is a one-line product change.
+    const d2 = mkdtempSync(join(tmpdir(), "prism-diag-e2-"));
+    const s2 = await seed(d2);
+    try {
+      await (s2 as unknown as { db: { execute: (q: string) => Promise<unknown> } })
+        .db.execute("PRAGMA wal_checkpoint(TRUNCATE)");
+      console.log("\n[E2] wal_checkpoint(TRUNCATE) issued");
+    } catch (error) {
+      console.log(`\n[E2] checkpoint failed: ${(error as Error).message}`);
+    }
+    await s2.close();
+    report("E2 checkpoint+close", d2);
+
+    // E3 — does the handle simply release late? Attempt 2 used 1s of retries
+    // and still failed, so a longer wait discriminates "slow" from "never".
+    const d3 = mkdtempSync(join(tmpdir(), "prism-diag-e3-"));
+    const s3 = await seed(d3);
+    await s3.close();
+    await new Promise((done) => setTimeout(done, 3_000));
+    report("E3 close+3s wait", d3);
+
+    // E4 — a RAW libsql client in WAL mode, with none of SqliteStorage's
+    // machinery. THE discriminator: if raw unlinks cleanly on Windows but
+    // SqliteStorage does not, the leak is ours (a second reference such as
+    // the ACT-R AccessLogBuffer), not libsql's.
+    const d4 = mkdtempSync(join(tmpdir(), "prism-diag-e4-"));
+    const { createClient } = await import("@libsql/client");
+    const raw4 = createClient({ url: `file:${join(d4, "isolated.db")}` });
+    await raw4.execute("PRAGMA journal_mode=WAL");
+    await raw4.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)");
+    await raw4.execute("INSERT INTO t (v) VALUES ('x')");
+    raw4.close();
+    report("E4 raw client, WAL", d4);
+
+    // E5 — raw client WITHOUT WAL. If DELETE journalling unlinks cleanly
+    // where WAL does not, the memory-mapped sidecars are confirmed and the
+    // product fix is a checkpoint (or journal mode) rather than a retry.
+    //
+    // Note: this must be set on a FRESH connection. Doing it through
+    // SqliteStorage after initialize() returned "SQLITE_BUSY: database is
+    // locked" even on macOS — itself a signal that something still holds a
+    // lock at that point.
+    const d5 = mkdtempSync(join(tmpdir(), "prism-diag-e5-"));
+    const raw5 = createClient({ url: `file:${join(d5, "isolated.db")}` });
+    await raw5.execute("PRAGMA journal_mode=DELETE");
+    await raw5.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)");
+    await raw5.execute("INSERT INTO t (v) VALUES ('x')");
+    raw5.close();
+    report("E5 raw client, DELETE", d5);
+
+    console.log("\n=== HOW TO READ THIS ===");
+    console.log("E1 EBUSY but E4 clean  -> the leak is in SqliteStorage, not libsql");
+    console.log("E4 EBUSY but E5 clean  -> WAL sidecars are memory-mapped; checkpoint/journal mode is the fix");
+    console.log("E2 clean but E1 EBUSY  -> wal_checkpoint(TRUNCATE) before close is the one-line product fix");
+    console.log("E3 still EBUSY         -> not a timing race; the handle is never released");
+    console.log("only -shm/-wal EBUSY   -> the db handle IS released; only sidecars linger");
+
+    for (const dir of [d1, d2, d3, d4, d5]) {
+      try { rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* reclaimed by OS */ }
+    }
+
+    // Platform-neutral: the run produced a report. The value is the output.
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
Found while preparing the marketplace submissions: `plugins/prism/.codex-plugin/plugin.json` still declared **20.6.0** after the 20.7.0 release.

`server.json` was guarded; this file was not — so a storefront submission would have advertised a version that no longer exists. Caught by reading it, which is exactly the kind of luck a guard should replace.

Generalizes the check: `VERSIONED_MANIFESTS` lists every other file that declares a version and ships to a storefront, each held to `package.json`'s value. Verified both directions — passes at 20.7.0, blocks a deliberately drifted 20.6.0.

Local CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)