### PR TITLE
fix(backup): close the DB before swapping the file on restore

### DIFF
--- a/scripts/check-publish-clean.mjs
+++ b/scripts/check-publish-clean.mjs
@@ -57,7 +57,7 @@ function checkVersionedManifests(repoRoot, expected) {
   return problems;
 }
 
-function checkServerManifest(repoRoot) {
+function checkManifestVersions(repoRoot) {
   // A repo without a registry manifest has nothing to drift: repos that never
   // published to the MCP Registry (and the guard's own test fixtures) must
   // pass untouched. Only an EXISTING manifest is held to the sync contract —
@@ -159,7 +159,7 @@ if (IS_MAIN) {
   }
 
   try {
-    const problems = checkServerManifest(process.cwd());
+    const problems = checkManifestVersions(process.cwd());
     if (problems.length) {
       console.error(
         "npm publish blocked: a versioned manifest disagrees with package.json.\n" +

--- a/scripts/ensure-dist.sh
+++ b/scripts/ensure-dist.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Guarantee dist/server.js exists after a checkout or merge.
+#
+# Why this exists (2026-08-05): BOTH hosts launch the MCP server by absolute
+# path into this working tree —
+#
+#   claude:  /usr/local/bin/node /Users/<you>/prism/dist/server.js
+#   codex:   same, via [mcp_servers.prism-mcp] in ~/.codex/config.toml
+#
+# and dist/ is gitignored, so it exists only when built. An rm -rf dist, a
+# failed build, or a branch checked out without built output therefore does
+# not merely break a CLI: it stops Prism loading in EVERY session on this
+# machine, for both hosts, until someone happens to rebuild.
+#
+# That failure is silent and confusing at the point of use — it surfaces as
+# "the MCP server won't connect" or "the browser CLI is broken", far from the
+# checkout that caused it. This rebuilds instead.
+#
+# Deliberately best-effort: a hook must never block a checkout or merge. If
+# the build fails, say so and let the developer decide.
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+[ -f dist/server.js ] && exit 0
+
+echo "[ensure-dist] dist/server.js is missing — the Prism MCP server is launched"
+echo "[ensure-dist] from this path, so both Claude Code and Codex would fail to"
+echo "[ensure-dist] start Prism. Rebuilding…"
+
+if npm run build >/tmp/prism-ensure-dist.log 2>&1; then
+  echo "[ensure-dist] ✓ rebuilt dist/"
+else
+  echo "[ensure-dist] ✗ build FAILED — Prism will not load until this is fixed." >&2
+  echo "[ensure-dist]   log: /tmp/prism-ensure-dist.log" >&2
+  echo "[ensure-dist]   run: npm run build" >&2
+fi
+exit 0

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -174,13 +174,35 @@ export async function getStorage(): Promise<StorageBackend> {
 }
 
 export async function closeStorage(): Promise<void> {
-  if (storageInstance) {
-    await storageInstance.close();
+  if (!storageInstance) return;
+  const closing = storageInstance;
+  // Clear the slot in `finally`: if close() throws, the previous code left a
+  // DEAD instance installed as the singleton, and every later getStorage()
+  // handed that broken connection to callers. An empty slot is strictly
+  // safer — the next getStorage() re-opens cleanly. The error still
+  // propagates, so a caller like restoreFromBackup can abort before swapping
+  // the database file.
+  try {
+    await closing.close();
+  } finally {
     storageInstance = null;
   }
 }
 
-/** Test-only: inject a pre-initialized storage instance into the singleton slot. */
+/**
+ * Test-only: inject a pre-initialized storage instance into the singleton slot.
+ *
+ * CONTRACT: the CALLER owns the lifecycle of what it injects. This function
+ * deliberately does NOT close the instance it replaces — callers pair the
+ * injection with their own cleanup (see createTestDb().cleanup), so closing
+ * here would double-close a storage the test still owns.
+ *
+ * Worth knowing when auditing handle leaks: an instance dropped without
+ * close() keeps its sqlite lock, and on Windows that lock blocks unlink of
+ * the database file until the process exits (libsql close() does not release
+ * it either — tursodatabase/libsql-js#228 — so closing is hygiene, not a
+ * guarantee).
+ */
 export function _setStorageForTesting(instance: StorageBackend | null): void {
   storageInstance = instance;
 }

--- a/src/utils/backup.ts
+++ b/src/utils/backup.ts
@@ -224,7 +224,22 @@ export async function restoreFromBackup(
         const preRestoreResult = await createBackup(dbPath);
         debugLog(`Pre-restore backup: ${preRestoreResult.success ? "OK" : "FAILED"}`);
 
-        // Copy backup over current database
+        // Release the live connection BEFORE overwriting the file.
+        //
+        // Reading a locked file is permitted — which is why createBackup()
+        // works — but writing ONTO one is not. Measured on windows-x64
+        // (2026-08-05): libsql does not release the database handle on
+        // close(), so unlink/overwrite fails EBUSY. Without this, restore
+        // failed on Windows *after* the pre-restore backup was written: it
+        // errored midway through the one operation whose entire purpose is
+        // recovery. POSIX tolerates overwriting an open file, so this was
+        // invisible on macOS and Linux.
+        const { closeStorage } = await import("../storage/index.js");
+        await closeStorage();
+
+        // Copy backup over current database. closeStorage() cleared the
+        // singleton, so the next getStorage() re-opens against the restored
+        // file and no caller retains a handle to the replaced one.
         copyFileSync(backupPath, dbPath);
 
         return {

--- a/src/utils/backup.ts
+++ b/src/utils/backup.ts
@@ -224,16 +224,19 @@ export async function restoreFromBackup(
         const preRestoreResult = await createBackup(dbPath);
         debugLog(`Pre-restore backup: ${preRestoreResult.success ? "OK" : "FAILED"}`);
 
-        // Release the live connection BEFORE overwriting the file.
+        // Release the live connection BEFORE swapping the file underneath it.
         //
-        // Reading a locked file is permitted — which is why createBackup()
-        // works — but writing ONTO one is not. Measured on windows-x64
-        // (2026-08-05): libsql does not release the database handle on
-        // close(), so unlink/overwrite fails EBUSY. Without this, restore
-        // failed on Windows *after* the pre-restore backup was written: it
-        // errored midway through the one operation whose entire purpose is
-        // recovery. POSIX tolerates overwriting an open file, so this was
-        // invisible on macOS and Linux.
+        // NOT a platform workaround. Measured on windows-x64 (2026-08-05):
+        // overwriting the database while a connection is open SUCCEEDS on
+        // every platform — SQLite shares the file for reading and writing,
+        // and only unlink/rename are blocked. So restore was never broken.
+        //
+        // The reason is correctness: replacing a database file beneath a live
+        // connection leaves that connection pointing at bytes it did not
+        // read, with a stale page cache and a WAL that no longer describes
+        // the file. SQLite documents this as unsafe. closeStorage() makes the
+        // swap atomic from the connection's point of view — the next
+        // getStorage() opens the restored file cleanly.
         const { closeStorage } = await import("../storage/index.js");
         await closeStorage();
 

--- a/tests/integration/e2e-daily-workflow.test.ts
+++ b/tests/integration/e2e-daily-workflow.test.ts
@@ -1011,7 +1011,13 @@ describe("Stability: Memory Leak Smoke", () => {
 // Stability: Isolation Under Concurrent Storage Instances
 // ═══════════════════════════════════════════════════════════════
 
-describe("Stability: Multi-Instance Isolation", () => {
+// Creates three SQLite databases in parallel, each running full migrations
+// and index creation, so it inherited vitest's 10s default while doing far
+// more I/O than a unit test. It passed on every runner except the slowest
+// (windows-20.x timed out at exactly 10000ms while windows-22.x passed the
+// same commit) — an under-specified timeout, not a flake. Heavy suites here
+// declare their own budget; cli-integration uses 30s.
+describe("Stability: Multi-Instance Isolation", { timeout: 30_000 }, () => {
   it("3 parallel storage instances have zero data leakage", async () => {
     const instances = await Promise.all(
       Array.from({ length: 3 }, (_, i) => createTestDb(`isolation-${i}`))

--- a/tests/integration/grounding-staleness.test.ts
+++ b/tests/integration/grounding-staleness.test.ts
@@ -92,20 +92,23 @@ describe("grounding staleness probe", () => {
         } finally {
             // Best-effort cleanup, deliberately non-fatal.
             //
-            // Two hypotheses were tested on CI and BOTH were wrong:
-            //   1. missing storage.close()  — added; windows still EBUSY
-            //   2. async handle release     — added maxRetries:10/retryDelay:100
-            //                                 (1s of retrying); still EBUSY
-            // So something holds the sqlite file open persistently on Windows
-            // even after close() resolves. That is worth understanding on its
-            // own terms — if SqliteStorage.close() does not release the file,
-            // Windows users cannot move, delete, or back up their DB — but it
-            // is a PRODUCT question, not a reason to fail a green suite in
-            // teardown. All 3746 assertions pass; only the rm throws.
+            // ROOT CAUSE, now identified (2026-08-05, measured on
+            // windows-x64): libsql's close() does not finalize outstanding
+            // prepared statements, so the connection — and its lock on the
+            // database file — survives until GC runs finalizers. Release is
+            // nondeterministic. Upstream: tursodatabase/libsql-js#228.
             //
-            // The directory lives under os.tmpdir() and is reclaimed by the
-            // OS. Do not convert this back to a throwing cleanup without
-            // first fixing the underlying handle release.
+            // That is why the two earlier fixes here could never have worked:
+            //   1. calling storage.close()   — close() is precisely what does
+            //                                  not release the handle
+            //   2. maxRetries/retryDelay     — a 3s wait fails too; it is not
+            //                                  a timing race
+            //
+            // On Windows the lock blocks unlink/rename ONLY; reading and
+            // overwriting still succeed, so no shipped feature is affected.
+            // POSIX permits unlinking an open file, which is why this is
+            // invisible on macOS and Linux. Cleanup therefore warns instead
+            // of failing a suite whose assertions all pass.
             try {
                 rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
             } catch (error) {

--- a/tests/migration.test.ts
+++ b/tests/migration.test.ts
@@ -24,9 +24,24 @@ describe('Migration Utility', () => {
   });
 
   afterAll(() => {
-    // Cleanup
-    if (fs.existsSync(TMP_DIR)) {
-      fs.rmSync(TMP_DIR, { recursive: true, force: true });
+    // Best-effort cleanup, deliberately non-fatal — same treatment as
+    // tests/integration/grounding-staleness.test.ts, and the same cause.
+    //
+    // libsql's close() does not finalize outstanding prepared statements, so
+    // a connection survives until GC runs finalizers
+    // (tursodatabase/libsql-js#228). On Windows that lingering handle keeps a
+    // file alive inside TMP_DIR, and the recursive remove fails with
+    // ENOTEMPTY on rmdir. POSIX permits unlinking open files, which is why
+    // this only ever breaks the windows legs.
+    //
+    // The assertions all pass; only teardown throws. Failing a green suite on
+    // an upstream handle leak we cannot fix from here would be noise, so warn
+    // instead. maxRetries covers the case where GC does run in time.
+    if (!fs.existsSync(TMP_DIR)) return;
+    try {
+      fs.rmSync(TMP_DIR, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    } catch (error) {
+      console.warn(`[migration.test] temp cleanup skipped: ${(error as Error).message}`);
     }
   });
 

--- a/tests/verification/windows-sqlite-handle.test.ts
+++ b/tests/verification/windows-sqlite-handle.test.ts
@@ -128,9 +128,12 @@ describe("Windows sqlite handle release (diagnostic)", { timeout: 60_000 }, () =
     report("E5 raw client, DELETE", d5);
 
     // E6 — the actual product operation: restoreFromBackup ends in
-    // copyFileSync(backup, dbPath), writing ONTO the live database. Reading
-    // from it (createBackup) is permitted, so backup works; this proves
-    // whether the WRITE direction fails, and whether closing first fixes it.
+    // copyFileSync(backup, dbPath), writing ONTO the live database.
+    //
+    // RESULT (windows-x64, measured): all three directions succeed. The lock
+    // blocks unlink/rename ONLY — not reading and not overwriting. Restore
+    // was therefore never broken on Windows; an earlier claim that it was had
+    // been inferred from the E1 unlink failure rather than measured.
     const d6 = mkdtempSync(join(tmpdir(), "prism-diag-e6-"));
     const s6 = await seed(d6);
     const live6 = join(d6, "isolated.db");
@@ -143,7 +146,7 @@ describe("Windows sqlite handle release (diagnostic)", { timeout: 60_000 }, () =
     } catch (error) {
       overwriteWhileOpen = `${(error as NodeJS.ErrnoException).code} (${(error as NodeJS.ErrnoException).syscall})`;
     }
-    console.log(`[E6] overwrite live db WHILE OPEN (restore, pre-fix): ${overwriteWhileOpen}`);
+    console.log(`[E6] overwrite live db WHILE OPEN: ${overwriteWhileOpen}`);
     await s6.close();
     let overwriteAfterClose = "OK";
     try {
@@ -151,7 +154,7 @@ describe("Windows sqlite handle release (diagnostic)", { timeout: 60_000 }, () =
     } catch (error) {
       overwriteAfterClose = `${(error as NodeJS.ErrnoException).code} (${(error as NodeJS.ErrnoException).syscall})`;
     }
-    console.log(`[E6] overwrite AFTER close() (restore, post-fix): ${overwriteAfterClose}`);
+    console.log(`[E6] overwrite AFTER close(): ${overwriteAfterClose}`);
 
     console.log("\n=== HOW TO READ THIS ===");
     console.log("E1 EBUSY but E4 clean  -> the leak is in SqliteStorage, not libsql");
@@ -159,8 +162,8 @@ describe("Windows sqlite handle release (diagnostic)", { timeout: 60_000 }, () =
     console.log("E2 clean but E1 EBUSY  -> wal_checkpoint(TRUNCATE) before close is the one-line product fix");
     console.log("E3 still EBUSY         -> not a timing race; the handle is never released");
     console.log("only -shm/-wal EBUSY   -> the db handle IS released; only sidecars linger");
-    console.log("E6 overwrite-while-open fails but after-close succeeds -> closeStorage()");
-    console.log("   before copyFileSync is the correct fix for restoreFromBackup");
+    console.log("E6 all three OK        -> the lock blocks unlink/rename ONLY, not");
+    console.log("   read or overwrite; restore is unaffected on every platform");
 
     for (const dir of [d1, d2, d3, d4, d5, d6]) {
       try { rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* reclaimed by OS */ }

--- a/tests/verification/windows-sqlite-handle.test.ts
+++ b/tests/verification/windows-sqlite-handle.test.ts
@@ -24,7 +24,7 @@
  * the database, or its memory-mapped WAL/SHM sidecars.
  */
 import { describe, it, expect } from "vitest";
-import { mkdtempSync, rmSync, existsSync, readdirSync, unlinkSync } from "node:fs";
+import { mkdtempSync, rmSync, existsSync, readdirSync, unlinkSync, copyFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SqliteStorage } from "../../src/storage/sqlite.js";
@@ -127,14 +127,42 @@ describe("Windows sqlite handle release (diagnostic)", { timeout: 60_000 }, () =
     raw5.close();
     report("E5 raw client, DELETE", d5);
 
+    // E6 — the actual product operation: restoreFromBackup ends in
+    // copyFileSync(backup, dbPath), writing ONTO the live database. Reading
+    // from it (createBackup) is permitted, so backup works; this proves
+    // whether the WRITE direction fails, and whether closing first fixes it.
+    const d6 = mkdtempSync(join(tmpdir(), "prism-diag-e6-"));
+    const s6 = await seed(d6);
+    const live6 = join(d6, "isolated.db");
+    const copy6 = join(d6, "backup.db");
+    copyFileSync(live6, copy6); // read direction — expected to succeed
+    console.log(`\n[E6] copy FROM live db (backup direction): OK`);
+    let overwriteWhileOpen = "unexpectedly succeeded";
+    try {
+      copyFileSync(copy6, live6); // write direction, connection still open
+    } catch (error) {
+      overwriteWhileOpen = `${(error as NodeJS.ErrnoException).code} (${(error as NodeJS.ErrnoException).syscall})`;
+    }
+    console.log(`[E6] overwrite live db WHILE OPEN (restore, pre-fix): ${overwriteWhileOpen}`);
+    await s6.close();
+    let overwriteAfterClose = "OK";
+    try {
+      copyFileSync(copy6, live6);
+    } catch (error) {
+      overwriteAfterClose = `${(error as NodeJS.ErrnoException).code} (${(error as NodeJS.ErrnoException).syscall})`;
+    }
+    console.log(`[E6] overwrite AFTER close() (restore, post-fix): ${overwriteAfterClose}`);
+
     console.log("\n=== HOW TO READ THIS ===");
     console.log("E1 EBUSY but E4 clean  -> the leak is in SqliteStorage, not libsql");
     console.log("E4 EBUSY but E5 clean  -> WAL sidecars are memory-mapped; checkpoint/journal mode is the fix");
     console.log("E2 clean but E1 EBUSY  -> wal_checkpoint(TRUNCATE) before close is the one-line product fix");
     console.log("E3 still EBUSY         -> not a timing race; the handle is never released");
     console.log("only -shm/-wal EBUSY   -> the db handle IS released; only sidecars linger");
+    console.log("E6 overwrite-while-open fails but after-close succeeds -> closeStorage()");
+    console.log("   before copyFileSync is the correct fix for restoreFromBackup");
 
-    for (const dir of [d1, d2, d3, d4, d5]) {
+    for (const dir of [d1, d2, d3, d4, d5, d6]) {
       try { rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch { /* reclaimed by OS */ }
     }
 


### PR DESCRIPTION
**Correction up front:** this PR originally claimed restore was *broken* on Windows. That was **inferred** from the E1 unlink failure, not measured — and the measurement refutes it.

## What windows-x64 actually shows (E6, measured)

| direction | result |
|---|---|
| read FROM the open db (backup) | OK |
| **overwrite the open db (restore)** | **OK** |
| overwrite after close() | OK |

SQLite shares the file for reading *and* writing. The libsql handle leak blocks **unlink/rename only**. **Restore was never broken, on any platform.**

## Why the change is still right

Not a platform workaround — a correctness fix that holds everywhere. Replacing a database file beneath a live connection leaves that connection pointing at bytes it never read, with a stale page cache and a WAL that no longer describes the file. SQLite documents this as unsafe. `closeStorage()` makes the swap atomic from the connection's point of view; the next `getStorage()` opens the restored file cleanly.

## Upstream

The handle leak is **not ours** — E4 shows a bare libsql client leaks identically. It is already filed as [tursodatabase/libsql-js#228](https://github.com/tursodatabase/libsql-js/issues/228): `close()` doesn't finalize prepared statements, so the connection survives until GC. Their macOS repro (`journal_mode=DELETE` → "database is locked") is the same symptom I hit locally. I'll add the win32 unlink consequence there rather than file a duplicate.

Local CI green; E1–E6 diagnostic re-run on windows-x64 in 47s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)