### PR TITLE
fix(storage): require TLS for remote cloud backends

### DIFF
--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -12,7 +12,20 @@ import { getSetting } from "./configStorage.js";
 export function isValidHttpUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
-    return parsed.protocol === "http:" || parsed.protocol === "https:";
+    if (parsed.protocol === "https:") return true;
+    // Plain http is accepted ONLY for loopback, where the traffic never leaves
+    // the machine — the local Supabase stack runs on 127.0.0.1:54321.
+    //
+    // Every caller of this function is gating a CLOUD backend, so accepting
+    // http for a remote host meant session content — summaries, decisions,
+    // filenames — could be sent unencrypted. The privacy policy states this
+    // traffic travels over TLS; before this change that was true only because
+    // the default base URL happens to be https, not because anything enforced
+    // it. A published claim should be guaranteed by the code, not by a default
+    // the user can silently override.
+    if (parsed.protocol !== "http:") return false;
+    const host = parsed.hostname;
+    return host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]";
   } catch {
     return false;
   }

--- a/tests/storage-url-tls.test.ts
+++ b/tests/storage-url-tls.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { isValidHttpUrl } from "../src/storage/index.js";
+
+/**
+ * The privacy policy states that cloud memory "travels over TLS". Before this
+ * guard that held only because the DEFAULT base URL is https — nothing stopped
+ * a user pointing PRISM_SYNALUX_BASE_URL at plain http, which would have sent
+ * session content (summaries, decisions, filenames) unencrypted while the
+ * published policy said otherwise. A claim in a privacy policy should be
+ * enforced by code, not left to a default.
+ */
+describe("cloud backend URL validation requires TLS", () => {
+  it("accepts https for remote hosts", () => {
+    expect(isValidHttpUrl("https://synalux.ai")).toBe(true);
+    expect(isValidHttpUrl("https://example.com:8443/base")).toBe(true);
+  });
+
+  it("REJECTS plain http for remote hosts", () => {
+    expect(isValidHttpUrl("http://synalux.ai")).toBe(false);
+    expect(isValidHttpUrl("http://evil.example.com")).toBe(false);
+    expect(isValidHttpUrl("http://192.168.1.10:3000")).toBe(false);
+  });
+
+  it("still allows http on loopback, where traffic never leaves the machine", () => {
+    // The local Supabase stack runs here; blocking it would break local dev.
+    expect(isValidHttpUrl("http://localhost:54321")).toBe(true);
+    expect(isValidHttpUrl("http://127.0.0.1:54321")).toBe(true);
+  });
+
+  it("rejects non-http protocols and malformed input", () => {
+    expect(isValidHttpUrl("ftp://synalux.ai")).toBe(false);
+    expect(isValidHttpUrl("file:///etc/passwd")).toBe(false);
+    expect(isValidHttpUrl("not a url")).toBe(false);
+  });
+});

--- a/tests/storage/auto-resolve.test.ts
+++ b/tests/storage/auto-resolve.test.ts
@@ -107,12 +107,20 @@ describe("isValidHttpUrl — URL validation edge cases", () => {
     // These pass the protocol check; defense-in-depth lives downstream
     // (HTTP client TLS validation, server-side allow-listing, etc.).
 
-    it("does not block SSRF-style URLs at this layer", () => {
-        // The resolver's URL check only validates protocol, not hostname.
-        // SSRF defense belongs in the HTTP client (or upstream allow-list),
-        // not here. This test pins the contract so a future tightening is
-        // an explicit decision, not an accident.
-        expect(isValidHttpUrl("http://169.254.169.254/latest/meta-data/")).toBe(true);
+    it("still does not block SSRF-style URLs at this layer", () => {
+        // The resolver's URL check validates protocol only, never hostname.
+        // SSRF defense belongs in the HTTP client (or an upstream allow-list),
+        // not here. The original version of this test pinned the contract so
+        // that "a future tightening is an explicit decision, not an accident";
+        // this IS that decision, recorded rather than silently absorbed.
+        //
+        // Changed 2026-08-06: plain http to a REMOTE host is now rejected,
+        // because the published privacy policy states cloud memory travels
+        // over TLS and only the default base URL was making that true. The
+        // metadata address over https still passes — hostname filtering
+        // remains out of scope here.
+        expect(isValidHttpUrl("https://169.254.169.254/latest/meta-data/")).toBe(true);
+        expect(isValidHttpUrl("http://169.254.169.254/latest/meta-data/")).toBe(false);
     });
 
     it("handles extremely long URLs without crashing", () => {


### PR DESCRIPTION
The published privacy policy states cloud memory travels over TLS. That held only because the **default** base URL is https — `isValidHttpUrl` accepted plain `http:` for any host.

So pointing `PRISM_SYNALUX_BASE_URL` or `SUPABASE_URL` at plain http would have sent session content (summaries, decisions, filenames) unencrypted, while the public policy said otherwise. A claim in a privacy policy should be guaranteed by code, not by a default the user can override.

- `https` required for remote hosts
- `http` still accepted on **loopback**, where traffic never leaves the machine — the local Supabase stack runs on `127.0.0.1:54321`

Updates `tests/storage/auto-resolve.test.ts`, whose own comment asked that a future tightening be *"an explicit decision, not an accident"*. This is that decision, recorded rather than absorbed: the metadata address over **https** still passes, since hostname filtering stays out of scope for this layer. Side effect: the classic `http://169.254.169.254` SSRF target is now rejected here.

4 new tests; local CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)