### PR TITLE
fix(storage): upgrade remote http cloud URLs to https instead of rejecting

### DIFF
--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -32,6 +32,37 @@ export function isValidHttpUrl(url: string): boolean {
 }
 
 /**
+ * Upgrade a remote http:// cloud URL to https:// rather than rejecting it.
+ *
+ * Rejecting was the first fix for the plaintext gap, and it closed the hole
+ * but reported it badly: a user who set an http base URL got "credentials are
+ * missing or invalid", which says nothing about the protocol being the
+ * problem. Upgrading keeps the guarantee — session content never leaves over
+ * plaintext — while letting a working configuration keep working.
+ *
+ * Loopback is left alone: http on 127.0.0.1 never crosses a network, and the
+ * local Supabase stack serves plain http on 54321.
+ *
+ * The upgrade is announced, not silent. If the host genuinely has no TLS
+ * listener the connection fails afterwards, and the log line is what explains
+ * why.
+ */
+export function upgradeInsecureCloudUrl(raw: string): string {
+  try {
+    const parsed = new URL(raw);
+    if (parsed.protocol !== "http:") return raw;
+    const host = parsed.hostname;
+    if (host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "[::1]") return raw;
+    parsed.protocol = "https:";
+    const upgraded = parsed.toString().replace(/\/+$/, "");
+    debugLog(`[Prism Storage] Upgraded ${raw} to ${upgraded}: session content is never sent over plaintext to a remote host.`);
+    return upgraded;
+  } catch {
+    return raw;
+  }
+}
+
+/**
  * Probe for synalux credentials: env vars first, then config DB.
  * Returns true if usable credentials are now in process.env.
  */
@@ -40,11 +71,13 @@ export async function ensureSynaluxCredentials(): Promise<boolean> {
   // Re-check process.env directly: SYNALUX_CONFIGURED is captured at module
   // load, so credentials injected later by another caller would be invisible
   // to it. Mirrors ensureSupabaseCredentials below.
-  const envUrl = process.env.PRISM_SYNALUX_BASE_URL?.trim() || process.env.SYNALUX_BASE_URL?.trim();
+  const rawEnvUrl = process.env.PRISM_SYNALUX_BASE_URL?.trim() || process.env.SYNALUX_BASE_URL?.trim();
+  const envUrl = rawEnvUrl ? upgradeInsecureCloudUrl(rawEnvUrl) : rawEnvUrl;
   const envKey = process.env.PRISM_SYNALUX_API_KEY?.trim();
   if (envUrl && envKey && isValidHttpUrl(envUrl)) return true;
-  const url = (await getSetting("PRISM_SYNALUX_BASE_URL"))?.trim() ||
+  const rawUrl = (await getSetting("PRISM_SYNALUX_BASE_URL"))?.trim() ||
     (await getSetting("SYNALUX_BASE_URL"))?.trim();
+  const url = rawUrl ? upgradeInsecureCloudUrl(rawUrl) : rawUrl;
   const key = (await getSetting("PRISM_SYNALUX_API_KEY"))?.trim();
   if (url && key && isValidHttpUrl(url)) {
     process.env.PRISM_SYNALUX_BASE_URL = url;
@@ -61,10 +94,12 @@ export async function ensureSynaluxCredentials(): Promise<boolean> {
  */
 async function ensureSupabaseCredentials(): Promise<boolean> {
   if (SUPABASE_CONFIGURED) return true;
-  const envUrl = process.env.SUPABASE_URL?.trim();
+  const rawEnvUrl = process.env.SUPABASE_URL?.trim();
+  const envUrl = rawEnvUrl ? upgradeInsecureCloudUrl(rawEnvUrl) : rawEnvUrl;
   const envKey = process.env.SUPABASE_KEY?.trim();
   if (envUrl && envKey && isValidHttpUrl(envUrl)) return true;
-  const url = (await getSetting("SUPABASE_URL"))?.trim();
+  const rawUrl = (await getSetting("SUPABASE_URL"))?.trim();
+  const url = rawUrl ? upgradeInsecureCloudUrl(rawUrl) : rawUrl;
   const key = (await getSetting("SUPABASE_KEY"))?.trim();
   if (url && key && isValidHttpUrl(url)) {
     process.env.SUPABASE_URL = url;

--- a/tests/storage-url-tls.test.ts
+++ b/tests/storage-url-tls.test.ts
@@ -33,3 +33,34 @@ describe("cloud backend URL validation requires TLS", () => {
     expect(isValidHttpUrl("not a url")).toBe(false);
   });
 });
+
+describe("insecure cloud URLs are upgraded, not just rejected", () => {
+  it("upgrades a remote http URL to https", async () => {
+    const { upgradeInsecureCloudUrl } = await import("../src/storage/index.js");
+    expect(upgradeInsecureCloudUrl("http://synalux.ai")).toBe("https://synalux.ai");
+    expect(upgradeInsecureCloudUrl("http://example.com:8080/base")).toBe("https://example.com:8080/base");
+  });
+
+  it("leaves loopback alone — that traffic never crosses a network", () => {
+    // The local Supabase stack serves plain http on 54321; upgrading it would
+    // break local development for no security gain.
+    return import("../src/storage/index.js").then(({ upgradeInsecureCloudUrl }) => {
+      expect(upgradeInsecureCloudUrl("http://127.0.0.1:54321")).toBe("http://127.0.0.1:54321");
+      expect(upgradeInsecureCloudUrl("http://localhost:54321")).toBe("http://localhost:54321");
+    });
+  });
+
+  it("leaves https and malformed input untouched", async () => {
+    const { upgradeInsecureCloudUrl } = await import("../src/storage/index.js");
+    expect(upgradeInsecureCloudUrl("https://synalux.ai")).toBe("https://synalux.ai");
+    expect(upgradeInsecureCloudUrl("not a url")).toBe("not a url");
+  });
+
+  it("an upgraded URL then PASSES validation, so the user is not blocked", async () => {
+    const { upgradeInsecureCloudUrl, isValidHttpUrl } = await import("../src/storage/index.js");
+    // Before: http://synalux.ai failed validation and surfaced as
+    // "credentials are missing or invalid" — a message about the wrong thing.
+    expect(isValidHttpUrl("http://synalux.ai")).toBe(false);
+    expect(isValidHttpUrl(upgradeInsecureCloudUrl("http://synalux.ai"))).toBe(true);
+  });
+});


### PR DESCRIPTION
Follow-up to #124, which closed the plaintext gap but reported it badly.

**Before this:** a user who set `PRISM_SYNALUX_BASE_URL=http://…` got *"credentials are missing or invalid"* — a message about entirely the wrong thing. The hole was closed; the diagnosis was misleading.

**Now:** the URL is upgraded to `https` and the upgrade is logged. The guarantee is unchanged — session content never leaves over plaintext to a remote host — but a working configuration keeps working instead of failing with a confusing error.

- Loopback untouched: `http://127.0.0.1:54321` never crosses a network, and the local Supabase stack serves plain http there
- Applied at **all four** cloud-URL reads (Synalux env + config DB, Supabase env + config DB)
- Announced, not silent: if the host has no TLS listener the connection fails afterwards, and that log line is what explains why

4 new tests, including one pinning that an upgraded URL then *passes* validation — proving the misleading error path is gone. Local CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)