### PR TITLE
fix(connect): skip codex MCP registration when a plugin already provides it

### DIFF
--- a/src/connect.ts
+++ b/src/connect.ts
@@ -8,6 +8,7 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  readdirSync,
   realpathSync,
   renameSync,
   statSync,
@@ -1597,6 +1598,23 @@ function registerCodexTomlHost(
     }
   }
 
+  // A Codex plugin may already register prism-mcp. Writing our own entry would
+  // configure the same server twice under one key, so every Prism tool appears
+  // in duplicate and load order decides which wins. Skip instead, and say why —
+  // an unexplained no-op is worse than the duplicate it prevents.
+  const providingPlugin = codexPluginProvidesPrismMcp(dirname(configPath));
+  if (providingPlugin && !locateCodexManagedBlock(originalText ?? "")) {
+    // "existing" rather than a new status: the server IS already registered,
+    // just by the plugin rather than by us. Nothing to do is the truth.
+    return result(
+      definition,
+      "existing",
+      `the Codex plugin ${providingPlugin} already registers prism-mcp; ` +
+      "not adding a second registration under the same key. Remove the plugin " +
+      "if you would rather prism connect manage this server.",
+    );
+  }
+
   let managedBlock: { start: number; end: number } | undefined;
   try {
     managedBlock = locateCodexManagedBlock(originalText ?? "");
@@ -1695,6 +1713,53 @@ function serializeCodexManagedBlock(entry: JsonObject, existingText: string): st
   const newline = existingText.includes("\r\n") ? "\r\n" : "\n";
   const serialized = stringifyToml({ mcp_servers: { "prism-mcp": entry } }).trimEnd();
   return `${CODEX_MANAGED_START}\n${serialized}\n${CODEX_MANAGED_END}\n`.replaceAll("\n", newline);
+}
+
+
+/**
+ * Is a Codex plugin already providing the prism-mcp server?
+ *
+ * Installing the plugin and running `prism connect` both register a server
+ * under the key `prism-mcp`, so doing both leaves the same server configured
+ * twice — every Prism tool appears in duplicate, and which one wins depends on
+ * load order. Previously this was only documented ("install the plugin OR run
+ * prism connect, not both"), which puts the burden on the user to remember.
+ *
+ * Detection reads the installed plugin's own manifest rather than matching a
+ * plugin NAME, so it keeps working if the plugin is renamed or vendored:
+ *   <codexHome>/plugins/cache/<marketplace>/<plugin>/<version>/.mcp.json
+ * Any enabled plugin whose .mcp.json declares a prism-mcp server counts.
+ */
+export function codexPluginProvidesPrismMcp(codexHome: string): string | null {
+  const cacheRoot = join(codexHome, "plugins", "cache");
+  let marketplaces: string[];
+  try {
+    marketplaces = readdirSync(cacheRoot);
+  } catch {
+    return null; // no plugins installed
+  }
+  for (const marketplace of marketplaces) {
+    let plugins: string[];
+    try { plugins = readdirSync(join(cacheRoot, marketplace)); } catch { continue; }
+    for (const plugin of plugins) {
+      let versions: string[];
+      try { versions = readdirSync(join(cacheRoot, marketplace, plugin)); } catch { continue; }
+      for (const version of versions) {
+        const manifest = join(cacheRoot, marketplace, plugin, version, ".mcp.json");
+        try {
+          const parsed = JSON.parse(readFileSync(manifest, "utf8")) as {
+            mcpServers?: Record<string, unknown>;
+          };
+          if (parsed?.mcpServers && Object.prototype.hasOwnProperty.call(parsed.mcpServers, "prism-mcp")) {
+            return `${plugin}@${marketplace}`;
+          }
+        } catch {
+          // absent or unreadable manifest — not a provider
+        }
+      }
+    }
+  }
+  return null;
 }
 
 function validateCodexCandidate(text: string): void {

--- a/tests/codex-plugin-collision.test.ts
+++ b/tests/codex-plugin-collision.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { codexPluginProvidesPrismMcp } from "../src/connect.js";
+
+/**
+ * Installing the Codex plugin and running `prism connect` both register a
+ * server under the key `prism-mcp`. Doing both configured the same server
+ * twice: every Prism tool appeared in duplicate and load order decided which
+ * won. It was previously only documented, which put the burden on the user.
+ */
+const dirs: string[] = [];
+afterEach(() => { while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true }); });
+
+function codexHome(): string {
+  const d = mkdtempSync(join(tmpdir(), "codex-collision-"));
+  dirs.push(d);
+  return d;
+}
+
+function installPlugin(home: string, marketplace: string, plugin: string, version: string, mcp: unknown) {
+  const dir = join(home, "plugins", "cache", marketplace, plugin, version);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, ".mcp.json"), JSON.stringify(mcp));
+}
+
+describe("detecting a Codex plugin that already provides prism-mcp", () => {
+  it("finds a plugin whose .mcp.json declares prism-mcp", () => {
+    const home = codexHome();
+    installPlugin(home, "prism", "synalux-prism", "20.7.1", {
+      mcpServers: { "prism-mcp": { command: "npx", args: ["-y", "prism-mcp-server"] } },
+    });
+    expect(codexPluginProvidesPrismMcp(home)).toBe("synalux-prism@prism");
+  });
+
+  it("matches on the manifest, not the plugin name — so a rename still works", () => {
+    const home = codexHome();
+    installPlugin(home, "acme", "totally-different-name", "1.0.0", {
+      mcpServers: { "prism-mcp": { command: "npx" } },
+    });
+    expect(codexPluginProvidesPrismMcp(home)).toBe("totally-different-name@acme");
+  });
+
+  it("does NOT false-positive on unrelated plugins", () => {
+    const home = codexHome();
+    installPlugin(home, "openai", "documents", "1.0.0", {
+      mcpServers: { "documents": { command: "node" } },
+    });
+    expect(codexPluginProvidesPrismMcp(home)).toBeNull();
+  });
+
+  it("returns null when nothing is installed or the manifest is unreadable", () => {
+    expect(codexPluginProvidesPrismMcp(codexHome())).toBeNull();
+    const home = codexHome();
+    const dir = join(home, "plugins", "cache", "m", "p", "1");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, ".mcp.json"), "{ not json");
+    expect(codexPluginProvidesPrismMcp(home)).toBeNull();
+  });
+});


### PR DESCRIPTION
Installing the Codex plugin **and** running `prism connect` both register a server under the key `prism-mcp`. Doing both configured the same server twice — every Prism tool appeared in duplicate, and load order decided which won.

Until now this was only *documented* ("install the plugin **or** run `prism connect`, not both"), which puts the burden on the user to remember a constraint the tool can enforce itself.

## Fix

`connect` detects a plugin-provided `prism-mcp` and reports **`existing`** rather than writing a second registration. `existing` instead of a new status because it's the truth: the server *is* already registered, just not by us.

Detection reads the installed plugin's own `.mcp.json` under `<codexHome>/plugins/cache/<marketplace>/<plugin>/<version>/` — **not the plugin name** — so it keeps working if the plugin is renamed or vendored. The path was verified against the real cache layout while installing `synalux-prism` in an isolated `CODEX_HOME`.

Two deliberate properties:
- **The skip is explained, never silent.** An unexplained no-op is worse than the duplicate it prevents, so the message names the plugin and how to opt out.
- **It does not fire when connect already owns a managed block**, so existing installs keep getting refreshed as before.

4 tests, including a no-false-positive case (an unrelated plugin declaring its own server) and unreadable-manifest handling. Local CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)