### PR TITLE
fix(connect): require a codex plugin to be ENABLED before skipping registration

### DIFF
--- a/src/connect.ts
+++ b/src/connect.ts
@@ -1602,7 +1602,17 @@ function registerCodexTomlHost(
   // configure the same server twice under one key, so every Prism tool appears
   // in duplicate and load order decides which wins. Skip instead, and say why —
   // an unexplained no-op is worse than the duplicate it prevents.
-  const providingPlugin = codexPluginProvidesPrismMcp(dirname(configPath));
+  // Build the set of plugins Codex will actually load: present in [plugins]
+  // and not explicitly disabled. Detection must not fire on a stale cache
+  // entry for a plugin that is disabled or gone.
+  const enabledPluginKeys = new Set<string>();
+  const pluginsTable = isJsonObject(config) ? config.plugins : undefined;
+  if (isJsonObject(pluginsTable)) {
+    for (const [key, entry] of Object.entries(pluginsTable)) {
+      if (isJsonObject(entry) && entry.enabled !== false) enabledPluginKeys.add(key);
+    }
+  }
+  const providingPlugin = codexPluginProvidesPrismMcp(dirname(configPath), enabledPluginKeys);
   if (providingPlugin && !locateCodexManagedBlock(originalText ?? "")) {
     // "existing" rather than a new status: the server IS already registered,
     // just by the plugin rather than by us. Nothing to do is the truth.
@@ -1728,9 +1738,19 @@ function serializeCodexManagedBlock(entry: JsonObject, existingText: string): st
  * Detection reads the installed plugin's own manifest rather than matching a
  * plugin NAME, so it keeps working if the plugin is renamed or vendored:
  *   <codexHome>/plugins/cache/<marketplace>/<plugin>/<version>/.mcp.json
- * Any enabled plugin whose .mcp.json declares a prism-mcp server counts.
+ *
+ * A cache manifest is necessary but NOT sufficient: a disabled or half-removed
+ * plugin leaves its .mcp.json on disk (verified 2026-08-06 — flipping
+ * `enabled = false` in config.toml does not clear the cache). Counting file
+ * presence alone would make `prism connect` skip its own registration for a
+ * plugin that is not actually providing the server, leaving the user with no
+ * prism-mcp at all. So the plugin@marketplace key must ALSO be enabled in the
+ * caller's parsed config for it to count.
  */
-export function codexPluginProvidesPrismMcp(codexHome: string): string | null {
+export function codexPluginProvidesPrismMcp(
+  codexHome: string,
+  enabledPluginKeys: ReadonlySet<string>,
+): string | null {
   const cacheRoot = join(codexHome, "plugins", "cache");
   let marketplaces: string[];
   try {
@@ -1750,8 +1770,13 @@ export function codexPluginProvidesPrismMcp(codexHome: string): string | null {
           const parsed = JSON.parse(readFileSync(manifest, "utf8")) as {
             mcpServers?: Record<string, unknown>;
           };
-          if (parsed?.mcpServers && Object.prototype.hasOwnProperty.call(parsed.mcpServers, "prism-mcp")) {
-            return `${plugin}@${marketplace}`;
+          const key = `${plugin}@${marketplace}`;
+          if (
+            enabledPluginKeys.has(key) &&
+            parsed?.mcpServers &&
+            Object.prototype.hasOwnProperty.call(parsed.mcpServers, "prism-mcp")
+          ) {
+            return key;
           }
         } catch {
           // absent or unreadable manifest — not a provider

--- a/tests/codex-plugin-collision.test.ts
+++ b/tests/codex-plugin-collision.test.ts
@@ -31,7 +31,7 @@ describe("detecting a Codex plugin that already provides prism-mcp", () => {
     installPlugin(home, "prism", "synalux-prism", "20.7.1", {
       mcpServers: { "prism-mcp": { command: "npx", args: ["-y", "prism-mcp-server"] } },
     });
-    expect(codexPluginProvidesPrismMcp(home)).toBe("synalux-prism@prism");
+    expect(codexPluginProvidesPrismMcp(home, new Set(["synalux-prism@prism"]))).toBe("synalux-prism@prism");
   });
 
   it("matches on the manifest, not the plugin name — so a rename still works", () => {
@@ -39,7 +39,7 @@ describe("detecting a Codex plugin that already provides prism-mcp", () => {
     installPlugin(home, "acme", "totally-different-name", "1.0.0", {
       mcpServers: { "prism-mcp": { command: "npx" } },
     });
-    expect(codexPluginProvidesPrismMcp(home)).toBe("totally-different-name@acme");
+    expect(codexPluginProvidesPrismMcp(home, new Set(["totally-different-name@acme"]))).toBe("totally-different-name@acme");
   });
 
   it("does NOT false-positive on unrelated plugins", () => {
@@ -47,15 +47,30 @@ describe("detecting a Codex plugin that already provides prism-mcp", () => {
     installPlugin(home, "openai", "documents", "1.0.0", {
       mcpServers: { "documents": { command: "node" } },
     });
-    expect(codexPluginProvidesPrismMcp(home)).toBeNull();
+    expect(codexPluginProvidesPrismMcp(home, new Set(["documents@openai"]))).toBeNull();
   });
 
   it("returns null when nothing is installed or the manifest is unreadable", () => {
-    expect(codexPluginProvidesPrismMcp(codexHome())).toBeNull();
+    expect(codexPluginProvidesPrismMcp(codexHome(), new Set())).toBeNull();
     const home = codexHome();
     const dir = join(home, "plugins", "cache", "m", "p", "1");
     mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, ".mcp.json"), "{ not json");
-    expect(codexPluginProvidesPrismMcp(home)).toBeNull();
+    expect(codexPluginProvidesPrismMcp(home, new Set(["p@m"]))).toBeNull();
+  });
+
+  it("does NOT count a plugin whose cache lingers but is disabled or removed", () => {
+    // The adversarial-review finding: a disabled/half-removed plugin keeps its
+    // cache .mcp.json on disk. If detection fired on file presence alone,
+    // prism connect would skip its own registration for a plugin that is not
+    // active — leaving the user with no prism-mcp server at all.
+    const home = codexHome();
+    installPlugin(home, "prism", "synalux-prism", "20.7.1", {
+      mcpServers: { "prism-mcp": { command: "npx" } },
+    });
+    // Cache is present, but the plugin is NOT in the enabled set.
+    expect(codexPluginProvidesPrismMcp(home, new Set())).toBeNull();
+    // And it IS counted once enabled — same cache, only the flag differs.
+    expect(codexPluginProvidesPrismMcp(home, new Set(["synalux-prism@prism"]))).toBe("synalux-prism@prism");
   });
 });


### PR DESCRIPTION
Adversarial-review finding against **#126's own code**, shipped earlier today.

## The defect

`codexPluginProvidesPrismMcp` checked **cache-manifest presence only** — it never read `config.toml`'s `enabled` flag — while its own doc comment claimed *"Any **enabled** plugin ... counts."* Doc says one thing, code does another.

## Why it matters

Verified: a **disabled or half-removed** plugin leaves its `.mcp.json` in `<codexHome>/plugins/cache/.../` on disk (flipping `enabled = false` does not clear the cache). So `prism connect` would report *"the plugin X already registers prism-mcp"* and **skip its own registration** for a plugin that is not active.

That's #126's failure mode inverted: instead of a **duplicate** server, the user ends up with **no** `prism-mcp` server at all — Prism silently doesn't load.

## Fix

The `plugin@marketplace` key must **also** be present-and-not-disabled in the caller's parsed `[plugins]` table. The parsed config was already in scope at the call site, so this is a small, contained change. A cache manifest is now *necessary but not sufficient*.

New test proves it against the same on-disk cache: detection returns `null` when the key is absent from the enabled set, and the plugin name when present — only the flag differs.

Local CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)