### PR TITLE
fix(registry): fit server.json description under the registry's 100-char cap, and guard it

### DIFF
--- a/scripts/check-publish-clean.mjs
+++ b/scripts/check-publish-clean.mjs
@@ -75,10 +75,31 @@ function checkManifestVersions(repoRoot) {
     throw error;
   }
   const packageJson = JSON.parse(rawPackage);
+  const serverJson = JSON.parse(rawServer);
   return [
-    ...serverManifestVersionMismatches(packageJson, JSON.parse(rawServer)),
+    ...serverManifestVersionMismatches(packageJson, serverJson),
     ...checkVersionedManifests(repoRoot, packageJson.version),
+    ...serverDescriptionTooLong(serverJson),
   ];
+}
+
+/**
+ * The MCP Registry rejects a server.json description over 100 characters
+ * (422 "expected length <= 100" — measured live 2026-08-06, when a 369-char
+ * description rewrite sailed through local CI and every manifest check, then
+ * failed the publish workflow on main). The registry validates in Go, so we
+ * bound BYTES, the stricter reading — a limit that passes here must pass
+ * there regardless of how it counts.
+ */
+const REGISTRY_DESCRIPTION_MAX = 100;
+
+export function serverDescriptionTooLong(serverJson) {
+  const description = serverJson?.description;
+  if (typeof description !== "string") return [];
+  const bytes = Buffer.byteLength(description, "utf8");
+  return bytes > REGISTRY_DESCRIPTION_MAX
+    ? [`server.json description is ${bytes} bytes; the MCP Registry rejects over ${REGISTRY_DESCRIPTION_MAX} (422 at publish time)`]
+    : [];
 }
 
 /**

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.dcostenco/prism-coder",
-  "description": "Persistent session memory for AI coding agents that never leaves your machine \u2014 including the on-device model that reasons over it. Restores your prior decisions, open TODOs, and changed files across sessions; adds associative recall of related past work, semantic drift detection, and local inference. Local-first by default. Works with Claude Code, Cursor, and Codex.",
+  "description": "Session memory for coding agents: local-first recall, drift detection, on-device inference.",
   "repository": {
     "url": "https://github.com/dcostenco/prism-coder",
     "source": "github"

--- a/tests/publish-clean-guard.test.ts
+++ b/tests/publish-clean-guard.test.ts
@@ -134,6 +134,41 @@ describe("published-version conflict guard", () => {
         expect(result.status).toBe(0);
     });
 
+    // The MCP Registry rejects a description over 100 chars with a 422 — at
+    // publish time, on main, after every local gate passed. Measured
+    // 2026-08-06 when a 369-char description rewrite failed exactly there.
+    // The guard must catch it before a PR merges, not after.
+    function repoWithDescription(description: string): string {
+        const repo = repoWithPackage("pkg", "1.0.0");
+        writeFileSync(
+            resolve(repo, "server.json"),
+            JSON.stringify({ name: "io.github.x/pkg", version: "1.0.0", description }, null, 2),
+        );
+        execFileSync("git", ["add", "server.json"], { cwd: repo });
+        execFileSync("git", ["commit", "--quiet", "-m", "server"], { cwd: repo });
+        return repo;
+    }
+
+    it("blocks a server.json description the registry would 422", () => {
+        const result = spawnSync(process.execPath, [SCRIPT, "--manifest-only"], {
+            cwd: repoWithDescription("x".repeat(101)),
+            encoding: "utf8",
+            env: { ...process.env },
+        });
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain("MCP Registry rejects over 100");
+    });
+
+    it("allows a description at exactly the registry limit", () => {
+        const result = spawnSync(process.execPath, [SCRIPT, "--manifest-only"], {
+            cwd: repoWithDescription("x".repeat(100)),
+            encoding: "utf8",
+            env: { ...process.env },
+        });
+        expect(result.stderr).not.toContain("MCP Registry");
+        expect(result.status).toBe(0);
+    });
+
     it("--manifest-only skips the published check, because the registry republish runs AFTER npm publish", () => {
         // Without this the guard blocks the very republish it exists to
         // protect: the registry workflow runs post-publish, so "this version


### PR DESCRIPTION
The #129 description rewrite (369 chars) passed every local gate, then the **MCP Registry publish on main failed**: 422 `expected length <= 100`. Caught by the post-merge live-listing check (the registry publish has now failed three times this cycle — this check earns its keep).

## Fix

- `server.json` description → **91 bytes**, still category-led: *"Session memory for coding agents: local-first recall, drift detection, on-device inference."*
- npm has no such cap — `package.json` keeps the long differentiator description.

## Guard

`checkManifestVersions` now rejects a `server.json` description over **100 bytes** (the stricter reading of the registry's Go-side validation), so the next rewrite fails **in the PR**, not in the publish workflow after merge. Subprocess tests pin both sides of the boundary: 101 blocks, 100 passes.

13/13 guard tests; local CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)