### PR TITLE
fix(ci): registry publish no-ops on duplicate-version instead of a red X

### DIFF
--- a/.github/workflows/registry-publish.yml
+++ b/.github/workflows/registry-publish.yml
@@ -38,6 +38,25 @@ jobs:
           tar xzf mcp-publisher.tar.gz
           sudo mv mcp-publisher /usr/local/bin/
       - name: Publish to MCP Registry
+        # Registry versions are immutable: a server.json change without a
+        # version bump (description edits, metadata) always gets 400
+        # "cannot publish duplicate version". That is the expected outcome for
+        # a metadata-only merge — the change rides the next release — not a
+        # failure. Verified 2026-08-06: a description-only merge produced a
+        # red X that read as "publish broken" while nothing was wrong. Only
+        # the duplicate-version rejection is tolerated; every other error
+        # still fails the job.
         run: |
           mcp-publisher login github-oidc
-          mcp-publisher publish
+          set +e
+          output=$(mcp-publisher publish 2>&1)
+          status=$?
+          set -e
+          printf '%s\n' "$output"
+          if [ $status -ne 0 ]; then
+            if printf '%s' "$output" | grep -q "duplicate version"; then
+              echo "::notice::Version already on the registry — metadata changes ride the next release. No-op."
+              exit 0
+            fi
+            exit $status
+          fi

--- a/DISCOVERY.md
+++ b/DISCOVERY.md
@@ -38,6 +38,21 @@ badge pointed at a different server (dcostenco/BCBA)."
 
 Use the canonical description above; repo URL `https://github.com/dcostenco/prism-coder`.
 
+## Paste-ready: amendment to Claude plugin review (submission shows old copy)
+
+The pending `claude-community` submission snapshots the form text, so the
+listing will publish with the pre-#128 description unless amended. Send via
+the submission confirmation email / plugin-review channel:
+
+> Subject: synalux-prism (pending review) — updated description
+>
+> While our submission for `synalux-prism` (repo
+> `dcostenco/prism-coder`, path `plugins/prism`) is pending review, we
+> refreshed the plugin description in the repo's `.claude-plugin/plugin.json`.
+> If the published listing uses the form text rather than the manifest, please
+> use the manifest description (current on `main`). No other change — same
+> slug, same repo, same path. Thanks!
+
 ## Measurement
 
 Re-check ~2 weeks after the external listings land:


### PR DESCRIPTION
Registry versions are **immutable**, but `registry-publish.yml` fires on **any** `server.json` change on main — so a metadata-only merge is *guaranteed* a red X: 400 `cannot publish duplicate version`. Happened today; read as 'publish broken' while nothing was wrong.

**Change:** the publish step tolerates only the duplicate-version rejection (`::notice` + exit 0 — the change rides the next release). Every other error still fails the job, and the fail-closed manifest guard above is untouched.

Also adds the paste-ready amendment text for Claude plugin review to `DISCOVERY.md` (the pending submission snapshots the old form text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)