### PR TITLE
release: 20.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 All notable changes to this project will be documented in this file.
 
+## [20.8.0] - 2026-08-06 — Found, Then Kept
+
+### Added
+- **First run proves the memory works instead of describing it.** A memory
+  product's payoff is structurally deferred: "it remembered" cannot be felt
+  until you come back, and most trial users never do. `session_bootstrap` now
+  seeds one demo memory on first run and shows it *recalled* — rendered
+  exclusively from the storage read-back, so a broken backend produces no block
+  rather than a convincing fake one. Lives in its own `prism-demo` project,
+  announces its own removability, one-shot via the durable first-run marker,
+  and idempotent so concurrent first runs cannot double-seed.
+
+### Changed
+- **Discovery metadata rewritten across every surface.** The MCP Registry
+  search is name-only: `memory`, `session memory`, and `coding agent memory`
+  each returned Prism zero times, so nobody who did not already know the name
+  could find it. npm descriptions led with acronyms ("SLERP-optimized GRPO
+  alignment, Zero-Search HDC/HRR retrieval") and `package.json` carried 62
+  keywords including `telepathy`, `morning-briefing`, and `reality-drift` — a
+  spam signal registries downrank. Descriptions now lead with the four things
+  measured as rare among 73 direct competitors (local inference: 2, drift
+  detection: 2, associative recall: ~6 of 2298); keywords trimmed 62 -> 12.
+- **Plugin description leads with the differentiators**, not the commodity
+  phrase four community competitors use verbatim.
+
+### Fixed
+- **Codex plugin detection required only a cached manifest, never an enabled
+  plugin.** A disabled or half-removed plugin leaves its `.mcp.json` on disk, so
+  `connect` could skip its own registration for a plugin that was not providing
+  the server — leaving the user with no `prism-mcp` at all.
+- **The registry rejects a description over 100 characters (422).** npm has no
+  such cap, so the rewrite passed every local gate and failed after merge. The
+  publish guard now enforces the limit in the PR, bounded in bytes.
+- **Registry publish no longer reports a red X for metadata-only merges.**
+  Registry versions are immutable, so a `server.json` change without a version
+  bump always returns "cannot publish duplicate version" — the expected
+  outcome, not a failure. Only that rejection is tolerated; every other error
+  still fails the job.
+- **TLS is enforced rather than assumed** for cloud storage URLs: a remote
+  `http://` endpoint is upgraded to `https://` instead of silently sending
+  session content in the clear. The privacy policy's claim is now true by
+  construction.
+
 ## [20.7.1] - 2026-08-06 — The Guard That Blocked Its Own Release
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-mcp-server",
-  "version": "20.7.1",
+  "version": "20.8.0",
   "mcpName": "io.github.dcostenco/prism-coder",
   "description": "Persistent session memory for AI coding agents that never leaves your machine \u2014 including the on-device model that reasons over it. Restores your prior decisions, open TODOs, and changed files across sessions; adds associative recall of related past work, semantic drift detection, and local inference. Local-first by default. Works with Claude Code, Cursor, and Codex.",
   "module": "index.ts",

--- a/plugins/prism/.claude-plugin/plugin.json
+++ b/plugins/prism/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "synalux-prism",
   "description": "Your coding agent forgets everything between sessions. Prism gives it a memory that sticks: your decisions, open TODOs, and changed files, restored the moment you return. It goes past a notes store \u2014 associative recall surfaces related past work, drift detection catches a long session wandering off-goal, and an on-device model reasons over all of it. Local-only by default: your work and the model reading it never leave your machine.",
-  "version": "20.7.1",
+  "version": "20.8.0",
   "author": {
     "name": "Synalux",
     "email": "support@synalux.ai"

--- a/plugins/prism/.codex-plugin/plugin.json
+++ b/plugins/prism/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synalux-prism",
-  "version": "20.7.1",
+  "version": "20.8.0",
   "description": "Your coding agent forgets everything between sessions. Prism gives it a memory that sticks: your decisions, open TODOs, and changed files, restored the moment you return. It goes past a notes store \u2014 associative recall surfaces related past work, drift detection catches a long session wandering off-goal, and an on-device model reasons over all of it. Local-only by default: your work and the model reading it never leave your machine.",
   "author": {
     "name": "Synalux"

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/dcostenco/prism-coder",
     "source": "github"
   },
-  "version": "20.7.1",
+  "version": "20.8.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "prism-mcp-server",
-      "version": "20.7.1",
+      "version": "20.8.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Carries the discovery + retention work to the surfaces still serving stale metadata. **npm and the MCP Registry are immutable per version**, so every description/keyword change merged this cycle has been inert on them until this bump.

## Added
- **First-run seed-and-show** — proves the save→recall loop in session 1 instead of deferring the payoff to a session 2 most trial users never reach.

## Changed
- Descriptions + keywords (62 → 12) across `package.json`, `server.json`, and both plugin manifests now lead with what's measurably rare among 73 direct competitors — local inference (2), drift detection (2), associative recall (~6 of 2298).

## Fixed
- Codex plugin **enabled-state** detection (a stale cache could make `connect` skip its own registration)
- Registry's **100-char description cap** — now guarded in the PR, not discovered after merge
- Duplicate-version publish red-X noise
- **TLS enforced** for cloud storage URLs

Version bumped in all four manifests the guard checks; local CI green.

**After merge:** publish fires on a `v20.8.0` tag push — which needs GitHub Actions, currently in `major_outage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)