### PR TITLE
release: 20.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [20.8.1] - 2026-08-07 — The Dashboard Was Never Loading
+
+### Fixed
+- **The dashboard's inline script has been parse-dead since 2026-05-29.** A
+  quoting typo (`data-id='''`) introduced by the May XSS fix was a
+  SyntaxError that killed the entire script at parse time — every dashboard
+  from 20.6 through 20.8.0 rendered "Loading projects..." forever: project
+  selector, neural graph, session ledger, all dead. Found while capturing a
+  real screenshot for the README; the picture would not populate, and the
+  reason was real. Fixed with a double-quoted attribute (escapeHtml escapes
+  the quotes, so it stays injection-safe) and verified live: projects load,
+  the graph renders, zero page errors.
+- **The ES5 dashboard lint now parses the built output.** The lint existed
+  precisely for quote-escaping traps and stayed green through ten weeks of a
+  parse-dead dashboard, because it pattern-matched known traps instead of
+  parsing. It now renders the built dashboard HTML and runs node --check on
+  every inline script block — proven against this exact defect: broken source
+  fails naming the line, fixed source passes.
+
+### Changed
+- README hero and docs images are now real captures of the running v20.8
+  dashboard (scrubbed profile, authored demo data), replacing the generated
+  mockup. Dead BFCL blog link now points at the canonical leaderboard, and the
+  missing "What's New" entries for 20.7–20.8.0 are in place.
+
 ## [20.8.0] - 2026-08-06 — Found, Then Kept
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prism-mcp-server",
-  "version": "20.8.0",
+  "version": "20.8.1",
   "mcpName": "io.github.dcostenco/prism-coder",
   "description": "Persistent session memory for AI coding agents that never leaves your machine \u2014 including the on-device model that reasons over it. Restores your prior decisions, open TODOs, and changed files across sessions; adds associative recall of related past work, semantic drift detection, and local inference. Local-first by default. Works with Claude Code, Cursor, and Codex.",
   "module": "index.ts",

--- a/plugins/prism/.claude-plugin/plugin.json
+++ b/plugins/prism/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "synalux-prism",
   "description": "Your coding agent forgets everything between sessions. Prism gives it a memory that sticks: your decisions, open TODOs, and changed files, restored the moment you return. It goes past a notes store \u2014 associative recall surfaces related past work, drift detection catches a long session wandering off-goal, and an on-device model reasons over all of it. Local-only by default: your work and the model reading it never leave your machine.",
-  "version": "20.8.0",
+  "version": "20.8.1",
   "author": {
     "name": "Synalux",
     "email": "support@synalux.ai"

--- a/plugins/prism/.codex-plugin/plugin.json
+++ b/plugins/prism/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "synalux-prism",
-  "version": "20.8.0",
+  "version": "20.8.1",
   "description": "Your coding agent forgets everything between sessions. Prism gives it a memory that sticks: your decisions, open TODOs, and changed files, restored the moment you return. It goes past a notes store \u2014 associative recall surfaces related past work, drift detection catches a long session wandering off-goal, and an on-device model reasons over all of it. Local-only by default: your work and the model reading it never leave your machine.",
   "author": {
     "name": "Synalux"

--- a/server.json
+++ b/server.json
@@ -6,13 +6,13 @@
     "url": "https://github.com/dcostenco/prism-coder",
     "source": "github"
   },
-  "version": "20.8.0",
+  "version": "20.8.1",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "prism-mcp-server",
-      "version": "20.8.0",
+      "version": "20.8.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Patch release carrying the dashboard fix — **the inline script was parse-dead since 2026-05-29**, so every dashboard from 20.6 through 20.8.0 rendered "Loading projects…" forever. Ships the fix, the hardened lint (parses built output, A/B proven against this exact defect), and the real README screenshots.

All four manifests bumped; changelog written; local CI green. Publish via trusted-publishing dispatch after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)