### PR TITLE
ci(local): close the two gaps that let today's failures through

### DIFF
--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -43,9 +43,30 @@ leak_guard() {
   return $failed
 }
 
+
+# ── npm ci parity, on linux ─────────────────────────────────────────────────
+# CI installs with `npm ci`, which fails hard when package.json and the
+# lockfile disagree. Running it on macOS is NOT equivalent: @emnapi/core and
+# @emnapi/runtime are platform-specific optional deps — unused here, REQUIRED
+# on linux — so any lockfile regenerated on macOS prunes them, `npm ci
+# --dry-run` still passes locally, and every linux and macOS CI leg then fails
+# with "Missing: @emnapi/runtime from lock file". That cost three attempts on
+# 2026-08-08. Docker is the only way to check it from this machine.
+# Skips (does not fail) when Docker is unavailable, so the script still works
+# without it — but prints loudly, because a skipped guard is not a passed one.
+npm_ci_linux() {
+  if ! docker info >/dev/null 2>&1; then
+    printf '\033[33m  SKIPPED — Docker not running; lockfile/linux parity UNVERIFIED\033[0m\n'
+    return 0
+  fi
+  docker run --rm -v "$PWD":/w -w /w node:22-slim sh -c 'npm ci --dry-run' >/dev/null 2>&1
+}
+
+step "npm ci parity (linux)"     npm_ci_linux
 step "Audit Dependencies"        npm audit --audit-level=high
 step "Private repo leak guard"   leak_guard
 step "Build TypeScript"          npm run build
+step "Raw-inference chokepoint"  node scripts/no-raw-inference.mjs
 step "Run Unit Tests"            npx vitest run --exclude tests/verification/cli-integration.test.ts
 step "Process-Level CLI Tests"   npx vitest run tests/verification/cli-integration.test.ts
 


### PR DESCRIPTION
`local-ci.sh` ran **5 of the CI job's 11 steps**. The two it skipped are exactly the two that broke `main` today.

## 1. `npm ci` parity — run on **Linux**, via Docker

CI installs with `npm ci`, which fails hard when `package.json` and the lockfile disagree. **Running it on macOS is not equivalent:** `@emnapi/core` and `@emnapi/runtime` are platform-specific optional deps — unused on macOS ARM, **required on Linux**. A lockfile regenerated here prunes them, `npm ci --dry-run` still passes locally, and every Linux and macOS leg then fails with *"Missing: @emnapi/runtime from lock file"*.

Three attempts were burned on that before Docker was tried. Now it's one local step.

Skips **loudly** when Docker isn't running — a skipped guard is not a passed one.

## 2. Raw-inference chokepoint guard

`scripts/no-raw-inference.mjs` — CI runs it, this script never called it.

## Verified against the real defect

Prune the emnapi entries as macOS would → the step **fails**. Restore them → **passes**. Not assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)