### PR TITLE
fix(skills): repair managed directories that exist but cannot be entered

### DIFF
--- a/src/skillManifestSync.ts
+++ b/src/skillManifestSync.ts
@@ -1,7 +1,8 @@
 import { createHash, randomUUID } from "node:crypto";
 import { constants as fsConstants } from "node:fs";
 import {
-  access, lstat, mkdir, mkdtemp, open, readFile, readdir, readlink, realpath, rename, rm, writeFile,
+  access, chmod, lstat, mkdir, mkdtemp, open, readFile, readdir, readlink, realpath, rename, rm,
+  writeFile,
 } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
@@ -391,6 +392,25 @@ async function ensureRealDirectory(path: string): Promise<void> {
   if (!(await exists(path))) await mkdir(path, { recursive: true, mode: 0o700 });
   const stat = await lstat(path);
   if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error(`managed path must be a real directory: ${path}`);
+  // Existing-but-unusable is the failure this repairs. mkdir's mode is masked
+  // by the creating process's umask, so a umask carrying the owner-execute bit
+  // (0o100) yields drw------- — a directory nothing can enter. Every later
+  // mkdtemp then throws EACCES, materialization aborts, and the run reports
+  // "partial" to stderr the host does not surface.
+  //
+  // Measured 2026-08-10: this exact directory sat at 0o600 for NINE days.
+  // The config DB half of each sync committed the new generation and digests
+  // while the file half never ran, so the client reported itself current while
+  // every managed skill root stayed frozen at its 2026-08-01 content. Checking
+  // "is a real directory" without checking "can I use it" made the outage
+  // permanent — nothing in the loop ever repaired the mode.
+  // Restore 0o700 exactly rather than OR-ing owner bits onto whatever is there.
+  // These directories stage entitled skill content and pre-rollback backups, and
+  // every creation site already asks for 0o700; repairing 0o066 to 0o766 would
+  // "fix" the outage by leaving the staging area group- and world-accessible.
+  // The branch only fires on a directory already missing owner rwx — broken by
+  // definition — so no deliberate sharing mode is being overridden.
+  if ((stat.mode & 0o700) !== 0o700) await chmod(path, 0o700);
 }
 
 async function removeExpiredTransactions(base: string): Promise<void> {
@@ -621,6 +641,8 @@ async function materializeNative(
   await mkdir(agentsSkillsDir, { recursive: true, mode: 0o700 });
   const rootStat = await lstat(agentsSkillsDir);
   if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) throw new Error("native skills root must be a real directory");
+  // The readdir immediately below is the first thing an unusable root breaks.
+  if ((rootStat.mode & 0o700) !== 0o700) await chmod(agentsSkillsDir, 0o700);
   await quarantineLegacyDiscoveryArtifacts(agentsSkillsDir);
   // Transaction content must remain outside the native discovery root: some
   // hosts recursively scan it and would otherwise discover staged/pruned paid
@@ -848,6 +870,11 @@ async function acquireSyncLock(agentsSkillsDir: string, waitMs = LOCK_WAIT_MS): 
   await mkdir(agentsSkillsDir, { recursive: true, mode: 0o700 });
   const rootStat = await lstat(agentsSkillsDir);
   if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) throw new Error("native skills root must be a real directory");
+  // Same repair as ensureRealDirectory. This site takes the lock before any
+  // materialization, so a root that exists without owner rwx fails here first —
+  // mkdir no-ops on an existing directory and every open below throws EACCES,
+  // with nothing in the loop restoring the mode.
+  if ((rootStat.mode & 0o700) !== 0o700) await chmod(agentsSkillsDir, 0o700);
   const lockPath = join(agentsSkillsDir, ".prism-sync.lock");
   const deadline = Date.now() + Math.max(0, waitMs);
   const token = randomUUID();

--- a/src/skillManifestSync.ts
+++ b/src/skillManifestSync.ts
@@ -388,6 +388,27 @@ type NativeOperation =
   | { type: "update"; name: string; target: string; backup: string }
   | { type: "prune"; name: string; target: string; backup: string };
 
+/**
+ * Restore owner rwx on a managed directory that exists but cannot be entered.
+ *
+ * Restores 0o700 EXACTLY rather than OR-ing owner bits onto whatever is there.
+ * These directories stage entitled skill content and pre-rollback backups, and
+ * every creation site already asks for 0o700; repairing 0o066 to 0o766 would
+ * "fix" an outage by leaving the staging area group- and world-accessible. It
+ * only fires on a directory already missing owner rwx — broken by definition —
+ * so no deliberate sharing mode is overridden.
+ *
+ * POSIX only. On Windows chmod maps to the read-only attribute alone and lstat
+ * reports 0o666 for every writable directory, so the condition can never be
+ * satisfied: without this guard the repair would fire on every call, chmod
+ * pointlessly, and still read back 0o666. The failure being repaired — a umask
+ * clearing the owner-execute bit — has no Windows analogue.
+ */
+async function repairOwnerAccess(path: string, mode: number): Promise<void> {
+  if (process.platform === "win32") return;
+  if ((mode & 0o700) !== 0o700) await chmod(path, 0o700);
+}
+
 async function ensureRealDirectory(path: string): Promise<void> {
   if (!(await exists(path))) await mkdir(path, { recursive: true, mode: 0o700 });
   const stat = await lstat(path);
@@ -404,13 +425,7 @@ async function ensureRealDirectory(path: string): Promise<void> {
   // every managed skill root stayed frozen at its 2026-08-01 content. Checking
   // "is a real directory" without checking "can I use it" made the outage
   // permanent — nothing in the loop ever repaired the mode.
-  // Restore 0o700 exactly rather than OR-ing owner bits onto whatever is there.
-  // These directories stage entitled skill content and pre-rollback backups, and
-  // every creation site already asks for 0o700; repairing 0o066 to 0o766 would
-  // "fix" the outage by leaving the staging area group- and world-accessible.
-  // The branch only fires on a directory already missing owner rwx — broken by
-  // definition — so no deliberate sharing mode is being overridden.
-  if ((stat.mode & 0o700) !== 0o700) await chmod(path, 0o700);
+  await repairOwnerAccess(path, stat.mode);
 }
 
 async function removeExpiredTransactions(base: string): Promise<void> {
@@ -642,7 +657,7 @@ async function materializeNative(
   const rootStat = await lstat(agentsSkillsDir);
   if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) throw new Error("native skills root must be a real directory");
   // The readdir immediately below is the first thing an unusable root breaks.
-  if ((rootStat.mode & 0o700) !== 0o700) await chmod(agentsSkillsDir, 0o700);
+  await repairOwnerAccess(agentsSkillsDir, rootStat.mode);
   await quarantineLegacyDiscoveryArtifacts(agentsSkillsDir);
   // Transaction content must remain outside the native discovery root: some
   // hosts recursively scan it and would otherwise discover staged/pruned paid
@@ -874,7 +889,7 @@ async function acquireSyncLock(agentsSkillsDir: string, waitMs = LOCK_WAIT_MS): 
   // materialization, so a root that exists without owner rwx fails here first —
   // mkdir no-ops on an existing directory and every open below throws EACCES,
   // with nothing in the loop restoring the mode.
-  if ((rootStat.mode & 0o700) !== 0o700) await chmod(agentsSkillsDir, 0o700);
+  await repairOwnerAccess(agentsSkillsDir, rootStat.mode);
   const lockPath = join(agentsSkillsDir, ".prism-sync.lock");
   const deadline = Date.now() + Math.max(0, waitMs);
   const token = randomUUID();

--- a/tests/skill-manifest-sync.test.ts
+++ b/tests/skill-manifest-sync.test.ts
@@ -163,7 +163,11 @@ describe("subscription-tier skill manifest sync", () => {
     }
   });
 
-  it("repairs an unusable managed directory to 0o700 without widening access", async () => {
+    // POSIX-only: Windows chmod maps to the read-only attribute alone and lstat
+  // reports 0o666 for every writable directory, so a directory that cannot be
+  // entered has no Windows analogue and the mode assertion is meaningless
+  // there. Ran red on windows-latest with "expected 438 to be 448" before this.
+it.skipIf(process.platform === "win32")("repairs an unusable managed directory to 0o700 without widening access", async () => {
     // Repairing must restore the creation intent, not merely unblock the run.
     // An earlier version of this fix OR-ed the owner bits onto whatever mode was
     // there, so 0o606 became 0o706 and the skills root — entitled, paid-tier
@@ -192,7 +196,11 @@ describe("subscription-tier skill manifest sync", () => {
       .toContain("name: prism-startup");
   });
 
-  it("materializes when the skills root itself cannot be entered", async () => {
+    // POSIX-only: Windows chmod maps to the read-only attribute alone and lstat
+  // reports 0o666 for every writable directory, so a directory that cannot be
+  // entered has no Windows analogue and the mode assertion is meaningless
+  // there. Ran red on windows-latest with "expected 438 to be 448" before this.
+it.skipIf(process.platform === "win32")("materializes when the skills root itself cannot be entered", async () => {
     // Found reviewing the transaction-directory fix: the root was guarded by a
     // plain mkdir (a no-op on an existing directory) plus a symlink check, so a
     // root left without owner rwx failed at the first readdir and nothing ever
@@ -213,7 +221,11 @@ describe("subscription-tier skill manifest sync", () => {
       .toContain("name: prism-startup");
   });
 
-  it("materializes through a pre-existing transaction directory that cannot be entered", async () => {
+    // POSIX-only: Windows chmod maps to the read-only attribute alone and lstat
+  // reports 0o666 for every writable directory, so a directory that cannot be
+  // entered has no Windows analogue and the mode assertion is meaningless
+  // there. Ran red on windows-latest with "expected 438 to be 448" before this.
+it.skipIf(process.platform === "win32")("materializes through a pre-existing transaction directory that cannot be entered", async () => {
     // The 2026-08-10 outage, reproduced. mkdir's mode is masked by the creating
     // process's umask, so a umask carrying the owner-execute bit leaves the
     // transaction base at drw------- : readable, writable, impossible to enter.

--- a/tests/skill-manifest-sync.test.ts
+++ b/tests/skill-manifest-sync.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { lstat, mkdtemp, mkdir, readFile, readdir, rename, rm, symlink, writeFile } from "node:fs/promises";
+import { chmod, lstat, mkdtemp, mkdir, readFile, readdir, rename, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -160,6 +160,94 @@ describe("subscription-tier skill manifest sync", () => {
       }
       await expect(readFile(join(nativeRoot, "current-staging-acceptance", "SKILL.md"), "utf8"))
         .rejects.toMatchObject({ code: "ENOENT" });
+    }
+  });
+
+  it("repairs an unusable managed directory to 0o700 without widening access", async () => {
+    // Repairing must restore the creation intent, not merely unblock the run.
+    // An earlier version of this fix OR-ed the owner bits onto whatever mode was
+    // there, so 0o606 became 0o706 and the skills root — entitled, paid-tier
+    // content — stayed world-readable on a shared machine. The observed outage
+    // was 0o600, where both forms yield 0o700, so only a mode carrying group or
+    // other bits distinguishes them.
+    const agentsSkillsDir = await root();
+    const transactionBase = join(dirname(agentsSkillsDir), ".prism-skill-transactions");
+    await mkdir(transactionBase, { recursive: true, mode: 0o700 });
+    await chmod(transactionBase, 0o606);          // owner rw, NO owner-x, other rw
+
+    // The base is deleted once it drains, so the mode has to be observed while
+    // the transaction is still open.
+    let modeDuringRun = -1;
+    const result = await synchronizeSkillManifest({
+      agentsSkillsDir, claudeCodeSkillsDir: false, cursorSkillsDir: false,
+      applyManifest: vi.fn(async () => undefined),
+      fetchImpl: vi.fn(() => jsonResponse(manifest("enterprise", ["enterprise-skill"]))) as unknown as typeof fetch,
+      beforeNativeCommit: async () => { modeDuringRun = (await lstat(transactionBase)).mode & 0o777; },
+      ...paidAuth,
+    });
+
+    expect(result.status).toBe("applied");
+    expect(modeDuringRun).toBe(0o700);
+    expect(await readFile(join(agentsSkillsDir, "prism-startup", "SKILL.md"), "utf8"))
+      .toContain("name: prism-startup");
+  });
+
+  it("materializes when the skills root itself cannot be entered", async () => {
+    // Found reviewing the transaction-directory fix: the root was guarded by a
+    // plain mkdir (a no-op on an existing directory) plus a symlink check, so a
+    // root left without owner rwx failed at the first readdir and nothing ever
+    // repaired it — the same permanent-silent-failure shape, one level up.
+    const agentsSkillsDir = await root();
+    await chmod(agentsSkillsDir, 0o606);
+
+    const result = await synchronizeSkillManifest({
+      agentsSkillsDir, claudeCodeSkillsDir: false, cursorSkillsDir: false,
+      applyManifest: vi.fn(async () => undefined),
+      fetchImpl: vi.fn(() => jsonResponse(manifest("enterprise", ["enterprise-skill"]))) as unknown as typeof fetch,
+      ...paidAuth,
+    });
+
+    expect(result.status).toBe("applied");
+    expect((await lstat(agentsSkillsDir)).mode & 0o777).toBe(0o700);
+    expect(await readFile(join(agentsSkillsDir, "prism-startup", "SKILL.md"), "utf8"))
+      .toContain("name: prism-startup");
+  });
+
+  it("materializes through a pre-existing transaction directory that cannot be entered", async () => {
+    // The 2026-08-10 outage, reproduced. mkdir's mode is masked by the creating
+    // process's umask, so a umask carrying the owner-execute bit leaves the
+    // transaction base at drw------- : readable, writable, impossible to enter.
+    // Every mkdtemp inside it then throws EACCES.
+    //
+    // The damage was silent because the halves of a sync commit independently:
+    // the config DB recorded the new generation and per-skill digests while no
+    // file was ever written, so the client reported itself current for nine
+    // days while every managed root stayed frozen at older content. A guard
+    // that asks "is this a real directory" and not "can I use it" cannot
+    // recover, because nothing in the loop repairs the mode.
+    const agentsSkillsDir = await root();
+    const claudeCodeSkillsDir = join(dirname(agentsSkillsDir), ".claude", "skills");
+    const cursorSkillsDir = join(dirname(agentsSkillsDir), ".cursor", "skills");
+    const transactionBase = join(dirname(agentsSkillsDir), ".prism-skill-transactions");
+    await mkdir(transactionBase, { recursive: true, mode: 0o700 });
+    await chmod(transactionBase, 0o600);
+    expect((await lstat(transactionBase)).mode & 0o700).not.toBe(0o700);
+
+    const snapshot = manifest("enterprise", ["enterprise-skill"]);
+    const result = await synchronizeSkillManifest({
+      agentsSkillsDir, claudeCodeSkillsDir, cursorSkillsDir,
+      applyManifest: vi.fn(async () => undefined),
+      fetchImpl: vi.fn(() => jsonResponse(snapshot)) as unknown as typeof fetch,
+      ...paidAuth,
+    });
+
+    // Without the repair this is "partial" with an EACCES mkdtemp error and no
+    // skill reaches disk, which is precisely how the outage presented.
+    expect(result.status).toBe("applied");
+    expect(result.error).toBeFalsy();
+    for (const nativeRoot of [agentsSkillsDir, claudeCodeSkillsDir, cursorSkillsDir]) {
+      expect(await readFile(join(nativeRoot, "prism-startup", "SKILL.md"), "utf8"))
+        .toContain("name: prism-startup");
     }
   });
 


### PR DESCRIPTION
Skill delivery on the maintainer's machine was dead for **nine days** and reported itself healthy throughout.

## The bug

`ensureRealDirectory` creates `.prism-skill-transactions` with `mode: 0o700`, but **mkdir's mode is masked by the creating process's umask**. A umask carrying the owner-execute bit yields `drw-------` — readable, writable, impossible to enter. Every `mkdtemp` inside it then throws `EACCES`.

What made it invisible is that the two halves of a sync commit independently. `applyManagedSkillManifest` wrote the new generation and per-skill digests to the config DB; native materialization then aborted on the EACCES and wrote no file at all. So the client reported itself **current** while every managed root — `.agents`, `.claude`, `.cursor` — stayed frozen at 9-day-old content: 12 stale files and 2 missing, including the validator that a shipped skill instructs agents to run. Codex and Gemini read `~/.agents/skills` too, so they were served stale content as well.

The status wasn't swallowed — `synchronizeSkillManifest` returned `"partial"` and `server.ts` logged it to stderr. But MCP stderr doesn't reach the user, so in practice `partial` and silence are the same thing.

The guard asked *"is this a real directory"* and never *"can I use it"*, so nothing repaired the mode and the failure was **permanent rather than transient**.

## Two things adversarial review of this fix changed

1. **Restore `0o700` exactly** instead of OR-ing owner bits onto the existing mode. These directories stage entitled skill content and pre-rollback backups; repairing `0o066` to `0o766` would "fix" the outage by leaving the staging area group- and world-readable. The observed mode was `0o600`, where both forms give `0o700` — so the first test *could not* have caught it. The branch fires only on a directory already missing owner rwx, so no deliberate sharing mode is overridden.
2. **The skills root had the same hole one level up.** It was guarded by a plain `mkdir` (a no-op on an existing directory) plus a symlink check, so a root left without owner rwx failed at the first `readdir` with nothing to repair it. Both root sites now carry the repair.

## Verification

Each test reproduces an **outage**, not a fix, and each was verified to fail without its change:

| Test | Failure without the fix |
|---|---|
| transaction directory unusable | `expected 'partial' to be 'applied'` |
| repair must not widen access | `454` (0o706) vs `448` (0o700) |
| skills root unusable | `expected 'failed' to be 'applied'` |

**112 tests pass** across the five skill suites; build clean.