### PR TITLE
fix(skills): defeat a persistent umask, not just one bad directory

### DIFF
--- a/src/agentManifestSync.ts
+++ b/src/agentManifestSync.ts
@@ -21,6 +21,7 @@
  */
 
 import { createHash, randomUUID } from "node:crypto";
+import { mkdirUsable, repairOwnerAccess } from "./utils/usableDirectory.js";
 import { link, lstat, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -359,11 +360,14 @@ export async function materializeAgentDefinitions(
   targetDir: string,
   render: AgentRenderer = renderClaudeAgent,
 ): Promise<AgentSyncOutcome> {
-  await mkdir(targetDir, { recursive: true, mode: 0o700 });
+  // Same umask trap as the skill roots: a masked mkdir leaves a directory
+  // nothing can enter, and every write below it then fails.
+  await mkdirUsable(targetDir);
   const rootStat = await lstat(targetDir);
   if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) {
     throw new Error("agent root must be a real directory");
   }
+  await repairOwnerAccess(targetDir, rootStat.mode);
   const indexPath = join(targetDir, INDEX);
   const index = await readIndex(indexPath);
   const owned = index?.files ?? {};

--- a/src/skillManifestSync.ts
+++ b/src/skillManifestSync.ts
@@ -16,6 +16,7 @@ import {
 } from "./agentManifestSync.js";
 import { FREE_NATIVE_SKILL_NAMES, REQUIRED_NATIVE_SKILL_NAMES } from "./tools/skillRouting.js";
 import { getSynaluxJwt, invalidateSynaluxJwt } from "./utils/synaluxJwt.js";
+import { mkdirUsable, repairOwnerAccess } from "./utils/usableDirectory.js";
 
 const OWNER = "prism-skill-sync-v1";
 const MARKER = ".prism-managed.json";
@@ -388,59 +389,7 @@ type NativeOperation =
   | { type: "update"; name: string; target: string; backup: string }
   | { type: "prune"; name: string; target: string; backup: string };
 
-/**
- * Restore owner rwx on a managed directory that exists but cannot be entered.
- *
- * Restores 0o700 EXACTLY rather than OR-ing owner bits onto whatever is there.
- * These directories stage entitled skill content and pre-rollback backups, and
- * every creation site already asks for 0o700; repairing 0o066 to 0o766 would
- * "fix" an outage by leaving the staging area group- and world-accessible. It
- * only fires on a directory already missing owner rwx — broken by definition —
- * so no deliberate sharing mode is overridden.
- *
- * POSIX only. On Windows chmod maps to the read-only attribute alone and lstat
- * reports 0o666 for every writable directory, so the condition can never be
- * satisfied: without this guard the repair would fire on every call, chmod
- * pointlessly, and still read back 0o666. The failure being repaired — a umask
- * clearing the owner-execute bit — has no Windows analogue.
- */
-async function repairOwnerAccess(path: string, mode: number): Promise<void> {
-  if (process.platform === "win32") return;
-  if ((mode & 0o700) !== 0o700) await chmod(path, 0o700);
-}
 
-/**
- * Create a directory, and any missing ancestors, that the owner can enter.
- *
- * mkdir's mode is masked by the process umask, and `recursive: true` applies
- * that same masked mode to every level it creates. Under a umask carrying the
- * owner-execute bit the FIRST created ancestor is already untraversable, so the
- * recursive call fails partway with EACCES before anything can repair it. Node
- * exposes no per-call umask, so creating level by level and repairing what we
- * just made is the only portable defeat.
- *
- * Repairs ONLY directories this call creates. A pre-existing ancestor -- $HOME
- * and everything above it -- keeps exactly the mode the user configured;
- * silently widening those would be a worse bug than the one being fixed.
- */
-async function mkdirUsable(target: string): Promise<void> {
-  if (process.platform === "win32") {
-    await mkdir(target, { recursive: true, mode: 0o700 });
-    return;
-  }
-  const segments = target.split(sep).filter(Boolean);
-  let current = isAbsolute(target) ? "" : ".";
-  for (const segment of segments) {
-    current = current === "" ? `${sep}${segment}` : `${current}${sep}${segment}`;
-    try {
-      await mkdir(current, { mode: 0o700 });
-    } catch (error) {
-      if (isErrno(error, "EEXIST")) continue;   // not ours -- do not touch its mode
-      throw error;
-    }
-    await chmod(current, 0o700);
-  }
-}
 
 async function ensureRealDirectory(path: string): Promise<void> {
   if (!(await exists(path))) await mkdirUsable(path);

--- a/src/skillManifestSync.ts
+++ b/src/skillManifestSync.ts
@@ -369,12 +369,12 @@ async function matchesIncomingSkill(path: string, skill: ManifestSkill): Promise
 
 async function stageSkill(root: string, skill: ManifestSkill, generation: string): Promise<string> {
   const target = join(root, skill.name);
-  await mkdir(target, { recursive: true, mode: 0o700 });
+  await mkdirUsable(target);
   const digests: Record<string, string> = Object.create(null);
   for (const [file, encoded] of Object.entries(skill.files)) {
     const path = resolve(target, file);
     if (!path.startsWith(`${target}${sep}`)) throw new Error(`unsafe resolved path: ${file}`);
-    await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+    await mkdirUsable(dirname(path));
     await writeFile(path, decodeFile(encoded), { mode: 0o600 });
     digests[file] = encoded.digest;
   }
@@ -409,8 +409,41 @@ async function repairOwnerAccess(path: string, mode: number): Promise<void> {
   if ((mode & 0o700) !== 0o700) await chmod(path, 0o700);
 }
 
+/**
+ * Create a directory, and any missing ancestors, that the owner can enter.
+ *
+ * mkdir's mode is masked by the process umask, and `recursive: true` applies
+ * that same masked mode to every level it creates. Under a umask carrying the
+ * owner-execute bit the FIRST created ancestor is already untraversable, so the
+ * recursive call fails partway with EACCES before anything can repair it. Node
+ * exposes no per-call umask, so creating level by level and repairing what we
+ * just made is the only portable defeat.
+ *
+ * Repairs ONLY directories this call creates. A pre-existing ancestor -- $HOME
+ * and everything above it -- keeps exactly the mode the user configured;
+ * silently widening those would be a worse bug than the one being fixed.
+ */
+async function mkdirUsable(target: string): Promise<void> {
+  if (process.platform === "win32") {
+    await mkdir(target, { recursive: true, mode: 0o700 });
+    return;
+  }
+  const segments = target.split(sep).filter(Boolean);
+  let current = isAbsolute(target) ? "" : ".";
+  for (const segment of segments) {
+    current = current === "" ? `${sep}${segment}` : `${current}${sep}${segment}`;
+    try {
+      await mkdir(current, { mode: 0o700 });
+    } catch (error) {
+      if (isErrno(error, "EEXIST")) continue;   // not ours -- do not touch its mode
+      throw error;
+    }
+    await chmod(current, 0o700);
+  }
+}
+
 async function ensureRealDirectory(path: string): Promise<void> {
-  if (!(await exists(path))) await mkdir(path, { recursive: true, mode: 0o700 });
+  if (!(await exists(path))) await mkdirUsable(path);
   const stat = await lstat(path);
   if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error(`managed path must be a real directory: ${path}`);
   // Existing-but-unusable is the failure this repairs. mkdir's mode is masked
@@ -653,7 +686,7 @@ async function materializeNative(
   agentsSkillsDir: string,
   hooks: Pick<SkillSyncOptions, "afterNativePrune" | "beforeNativeStage" | "beforeNativeCommit" | "beforeNativeCleanup">,
 ): Promise<Pick<SkillSyncResult, "installed" | "updated" | "pruned" | "conflicts">> {
-  await mkdir(agentsSkillsDir, { recursive: true, mode: 0o700 });
+  await mkdirUsable(agentsSkillsDir);
   const rootStat = await lstat(agentsSkillsDir);
   if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) throw new Error("native skills root must be a real directory");
   // The readdir immediately below is the first thing an unusable root breaks.
@@ -666,6 +699,10 @@ async function materializeNative(
   await ensureRealDirectory(transactionBase);
   await removeExpiredTransactions(transactionBase);
   const transactionRoot = await mkdtemp(join(transactionBase, "txn-"));
+  // mkdtemp is umask-masked too, and nothing else revisits this path. A
+  // persistent restrictive umask therefore produced a REPAIRED base holding a
+  // brand-new unusable txn-* directory -- the original outage one level deeper.
+  await repairOwnerAccess(transactionRoot, (await lstat(transactionRoot)).mode);
   const stageRoot = join(transactionRoot, "stage");
   const backupRoot = join(transactionRoot, "backup");
   await ensureRealDirectory(stageRoot);
@@ -882,7 +919,7 @@ async function fetchManifest(options: SkillSyncOptions): Promise<SkillManifest> 
 }
 
 async function acquireSyncLock(agentsSkillsDir: string, waitMs = LOCK_WAIT_MS): Promise<() => Promise<void>> {
-  await mkdir(agentsSkillsDir, { recursive: true, mode: 0o700 });
+  await mkdirUsable(agentsSkillsDir);
   const rootStat = await lstat(agentsSkillsDir);
   if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) throw new Error("native skills root must be a real directory");
   // Same repair as ensureRealDirectory. This site takes the lock before any

--- a/src/skillManifestSync.ts
+++ b/src/skillManifestSync.ts
@@ -7,7 +7,7 @@ import {
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import {
-  applyManagedSkillManifest, getSetting, refreshConfigStorageCache,
+  applyManagedSkillManifest, getSetting, refreshConfigStorageCache, setSetting,
 } from "./storage/configStorage.js";
 import {
   materializeAgentDefinitions, renderClaudeAgent, renderCodexAgent, renderGeminiAgent,
@@ -17,6 +17,17 @@ import {
 import { FREE_NATIVE_SKILL_NAMES, REQUIRED_NATIVE_SKILL_NAMES } from "./tools/skillRouting.js";
 import { getSynaluxJwt, invalidateSynaluxJwt } from "./utils/synaluxJwt.js";
 import { mkdirUsable, repairOwnerAccess } from "./utils/usableDirectory.js";
+
+/**
+ * Generation whose files actually reached disk, as opposed to the generation
+ * the config DB accepted. They diverge exactly when materialization fails, and
+ * that divergence is what made the 2026-08-10 outage invisible: the DB half
+ * commits first (deliberately -- committed names are what let a crashed run
+ * prune obsolete skills offline on restart), so the client reported the new
+ * generation while every managed root stayed frozen for nine days. Only a
+ * completed materialization advances this key.
+ */
+export const MATERIALIZED_GENERATION_KEY = "skill_manifest:materialized_generation";
 
 const OWNER = "prism-skill-sync-v1";
 const MARKER = ".prism-managed.json";
@@ -1021,6 +1032,10 @@ export async function synchronizeSkillManifest(options: SkillSyncOptions = {}): 
       native.conflicts.push(...outcome.conflicts);
     }
     const status = native.installed.length || native.updated.length || native.pruned.length ? "applied" : "unchanged";
+    // Reached only when every native root materialized. A failure above throws
+    // past this point, leaving the previous value so the mismatch persists and
+    // stays visible until a sync genuinely succeeds.
+    await setSetting(MATERIALIZED_GENERATION_KEY, manifest.generation);
     return {
       status,
       tier: manifest.tier,

--- a/src/storage/configStorage.ts
+++ b/src/storage/configStorage.ts
@@ -1,7 +1,8 @@
 import { createClient } from "@libsql/client";
 import { resolve, dirname } from "path";
 import { homedir } from "os";
-import { existsSync, mkdirSync } from "fs";
+import { existsSync } from "fs";
+import { mkdirUsableSync } from "../utils/usableDirectory.js";
 
 const PROTO_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
@@ -38,7 +39,10 @@ function getClient() {
     // and libSQL throws SQLITE_CANTOPEN (error 14) without it.
     const dir = dirname(CONFIG_PATH);
     if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true });
+      // Not plain mkdirSync: recursive creation is umask-masked at every level,
+      // and this directory holds the entitlement snapshot, so it must be private
+      // and enterable regardless of the umask Prism happens to inherit.
+      mkdirUsableSync(dir);
     }
     configClient = createClient({
       url: `file:${CONFIG_PATH}`,

--- a/src/tools/ledgerHandlers.ts
+++ b/src/tools/ledgerHandlers.ts
@@ -256,6 +256,8 @@ interface NativeSkillManifestSnapshot {
   source: "validated-partial" | "committed" | "tier-fallback";
   syncStatus: SkillSyncResult["status"];
   conflicts: string[];
+  /** Generation the DB accepted but whose files never reached disk. */
+  undeliveredGeneration: string;
 }
 
 function parseNativeSkillNames(value: string): string[] {
@@ -274,10 +276,32 @@ async function resolveNativeSkillManifestSnapshot(
   syncResult: SkillSyncResult,
 ): Promise<NativeSkillManifestSnapshot> {
   const { FREE_NATIVE_SKILL_NAMES, REQUIRED_NATIVE_SKILL_NAMES } = await import("./skillRouting.js");
-  const [storedNamesValue, storedTierValue] = await Promise.all([
-    getSetting("skill_manifest:names", "[]"),
-    getSetting("skill_manifest:tier", ""),
-  ]);
+  const [storedNamesValue, storedTierValue, committedGeneration, materializedGeneration] =
+    await Promise.all([
+      getSetting("skill_manifest:names", "[]"),
+      getSetting("skill_manifest:tier", ""),
+      getSetting("skill_manifest:generation", ""),
+      getSetting("skill_manifest:materialized_generation", ""),
+    ]);
+  // The DB half of a sync commits before files are written, by design: the
+  // committed names are what let a crashed run prune obsolete skills offline on
+  // restart. The cost is that this snapshot can describe an entitlement whose
+  // files never landed. A DIVERGENCE here is that exact state, and it persists
+  // across sessions -- a later sync reports "unchanged" because nothing needed
+  // writing, while the roots agents actually read stay frozen. Unreported, it
+  // ran for nine days on 2026-08-10.
+  // An EMPTY marker is "never recorded", not "never delivered": every install
+  // that predates the marker has a committed generation and no marker at all,
+  // and an offline user's failed fetch must not scream STALE at them on
+  // upgrade day. A false alarm here trains people to ignore the line, which is
+  // how the real one gets waved through. The fresh-install failure case is
+  // still covered -- that run's own syncStatus is "partial" and the
+  // validated-partial branch already reports materialization incomplete.
+  const undeliveredGeneration =
+    Boolean(committedGeneration) && Boolean(materializedGeneration) &&
+    committedGeneration !== materializedGeneration
+      ? committedGeneration
+      : "";
   const partialNamesInput = syncResult.status === "partial" && Array.isArray(syncResult.entitledNames)
     ? syncResult.entitledNames
     : null;
@@ -315,6 +339,7 @@ async function resolveNativeSkillManifestSnapshot(
     tier,
     source,
     syncStatus: syncResult.status,
+    undeliveredGeneration,
     conflicts: [...new Set(syncResult.conflicts)],
   };
 }
@@ -369,6 +394,16 @@ async function buildNativeSystemReadyBlock(
       `directory out of the native skills folder and rerun \`prism connect\` ` +
       `(or a session bootstrap) to reinstall the managed copy.`
     : "";
+  // Durable, not per-run: a later sync reports "unchanged" while the roots stay
+  // frozen from an earlier failed materialization. This line is the difference
+  // between that outage being visible on the next startup and it running for
+  // nine days.
+  const undeliveredWarning = snapshot.undeliveredGeneration
+    ? `\n> - ⚠️ **Skill files are STALE:** the entitlement DB is at generation ` +
+      `\`${snapshot.undeliveredGeneration.slice(0, 12)}…\` but its files never finished ` +
+      `reaching the skill roots. Agents are reading older skills. Run a sync ` +
+      `(restart the host or \`prism connect\`) and report this if it persists.`
+    : "";
   if (snapshot.source === "validated-partial") {
     return `> **Prism System Ready**\n>\n` +
       `> - 🪪 **Subscription tier:** ${snapshot.tier}\n` +
@@ -378,7 +413,7 @@ async function buildNativeSystemReadyBlock(
       `> - 🛠️ **Other tier entitlements:** ${formatBoundedSkillNames(otherTierSkills, "entitled")}\n` +
       `> - 🧠 **Context depth:** ${depth}\n` +
       `> - 🔄 **Skill sync:** ${SKILL_SYNC_STATUS_LABELS[snapshot.syncStatus]} · native materialization incomplete${conflictSuffix}` +
-      conflictWarning +
+      conflictWarning + undeliveredWarning +
       freeTierUpgradeLine(snapshot.tier);
   }
   if (snapshot.source === "tier-fallback") {
@@ -387,7 +422,7 @@ async function buildNativeSystemReadyBlock(
       `> - 🛡️ **Fallback skill names:** ${formatBoundedSkillNames(snapshot.names, "fallback")}\n` +
       `> - 🧠 **Context depth:** ${depth}\n` +
       `> - 🔄 **Skill sync:** ${SKILL_SYNC_STATUS_LABELS[snapshot.syncStatus]} · no committed manifest${conflictSuffix}` +
-      conflictWarning +
+      conflictWarning + undeliveredWarning +
       freeTierUpgradeLine(snapshot.tier);
   }
   return `> **Prism System Ready**\n>\n` +
@@ -398,7 +433,7 @@ async function buildNativeSystemReadyBlock(
     `> - 🛠️ **Other tier skills provisioned:** ${formatBoundedSkillNames(otherTierSkills, "provisioned")}\n` +
     `> - 🧠 **Context depth:** ${depth}\n` +
     `> - 🔄 **Skill sync:** ${SKILL_SYNC_STATUS_LABELS[snapshot.syncStatus]} · committed manifest${conflictSuffix}` +
-    conflictWarning +
+    conflictWarning + undeliveredWarning +
     freeTierUpgradeLine(snapshot.tier);
 }
 

--- a/src/utils/usableDirectory.ts
+++ b/src/utils/usableDirectory.ts
@@ -20,7 +20,7 @@
  * anywhere Prism creates a private directory — skill roots, agent roots, and the
  * config DB's parent — and a guard applied at two of three sites is not a guard.
  */
-import { chmodSync, lstatSync, mkdirSync } from "node:fs";
+import { constants as fsConstants, chmodSync, lstatSync, mkdirSync } from "node:fs";
 import { chmod, lstat, mkdir, open } from "node:fs/promises";
 import { isAbsolute, sep } from "node:path";
 
@@ -58,9 +58,23 @@ export async function repairOwnerAccess(path: string, mode: number): Promise<voi
   if ((mode & MANAGED_DIR_MODE) === MANAGED_DIR_MODE) return;
   let handle;
   try {
-    handle = await open(path, "r");
+    // O_NOFOLLOW: a symlink at this path must fail the open rather than hand us
+    // a descriptor to whatever it points at.
+    handle = await open(path, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
   } catch {
-    await chmod(path, MANAGED_DIR_MODE);   // platforms that refuse to open a directory
+    // Opening a directory needs owner-read, so the very modes this exists to
+    // repair (0o000, 0o300) land here — as does any symlink, via O_NOFOLLOW.
+    // An unguarded pathname chmod at this point re-opens the symlink hole: a
+    // link to an UNREADABLE file skipped the descriptor path entirely and got
+    // its target chmodded to 0o700. Proven with a live attack against the
+    // built helper during review, not hypothesized. lstat separates the two
+    // cases; the remaining lstat→chmod race is confined to unreadable real
+    // directories inside the user's own home.
+    const entry = await lstat(path);
+    if (!entry.isDirectory() || entry.isSymbolicLink()) {
+      throw new Error(`managed path is not a directory: ${path}`);
+    }
+    await chmod(path, MANAGED_DIR_MODE);
     return;
   }
   try {

--- a/src/utils/usableDirectory.ts
+++ b/src/utils/usableDirectory.ts
@@ -1,0 +1,132 @@
+/**
+ * Directory creation and repair that a restrictive umask cannot defeat.
+ *
+ * WHY THIS EXISTS (2026-08-10)
+ * Skill delivery died silently for nine days. `.prism-skill-transactions` had
+ * been created with `mkdir(..., { mode: 0o700 })`, but mkdir's mode is masked by
+ * the process umask: a umask carrying the owner-execute bit yields drw-------,
+ * a directory that can be read and written but never entered. Every subsequent
+ * mkdtemp threw EACCES, materialization aborted, and — because the config DB
+ * half of a sync commits before the file half — the client went on reporting the
+ * new generation while every managed skill root stayed frozen at older content.
+ *
+ * The first fix repaired a directory that was already broken and left the cause
+ * alone: a umask that is still restrictive masks every directory created after
+ * it, so a repaired base simply gained a brand-new unusable child. Node exposes
+ * no per-call umask, so the only portable defeat is to create one level at a
+ * time and repair what we just made.
+ *
+ * These helpers are shared rather than duplicated because the same trap exists
+ * anywhere Prism creates a private directory — skill roots, agent roots, and the
+ * config DB's parent — and a guard applied at two of three sites is not a guard.
+ */
+import { chmodSync, lstatSync, mkdirSync } from "node:fs";
+import { chmod, lstat, mkdir, open } from "node:fs/promises";
+import { isAbsolute, sep } from "node:path";
+
+/** Mode every Prism-managed directory is created with and repaired to. */
+export const MANAGED_DIR_MODE = 0o700;
+
+function isErrno(error: unknown, code: string): boolean {
+  return typeof error === "object" && error !== null && "code" in error
+    && (error as NodeJS.ErrnoException).code === code;
+}
+
+/**
+ * Restore owner rwx on a managed directory that exists but cannot be entered.
+ *
+ * Restores 0o700 EXACTLY rather than OR-ing owner bits onto whatever is there.
+ * These directories hold entitled skill content and pre-rollback backups;
+ * repairing 0o066 to 0o766 would "fix" an outage by leaving them world-readable.
+ *
+ * Prism-managed directories REQUIRE owner rwx, so a deliberate sharing mode that
+ * withholds it — 0o670, say — is discarded rather than preserved. Conventional
+ * sharing is unaffected: this only fires on a directory the owner cannot use,
+ * which is broken by any definition. A 0o770 directory is left untouched.
+ *
+ * Applies the change through an open descriptor, not the pathname. A pathname
+ * chmod re-resolves the path, so a process able to swap the directory for a
+ * symlink between the check and the change could redirect the permission change
+ * somewhere else entirely. fchmod acts on the object already opened.
+ *
+ * POSIX only. On Windows chmod maps to the read-only attribute alone and lstat
+ * reports 0o666 for every writable directory, so the condition can never be
+ * satisfied and the failure being repaired has no analogue there.
+ */
+export async function repairOwnerAccess(path: string, mode: number): Promise<void> {
+  if (process.platform === "win32") return;
+  if ((mode & MANAGED_DIR_MODE) === MANAGED_DIR_MODE) return;
+  let handle;
+  try {
+    handle = await open(path, "r");
+  } catch {
+    await chmod(path, MANAGED_DIR_MODE);   // platforms that refuse to open a directory
+    return;
+  }
+  try {
+    const opened = await handle.stat();
+    if (!opened.isDirectory()) throw new Error(`managed path is not a directory: ${path}`);
+    await handle.chmod(MANAGED_DIR_MODE);
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * Create a directory, and any missing ancestors, that the owner can enter.
+ *
+ * `recursive: true` applies the same masked mode to every level it creates, so
+ * under a hostile umask the first new ancestor is already untraversable and the
+ * call fails partway with EACCES before anything can repair it.
+ *
+ * Repairs ONLY directories this call creates. A pre-existing ancestor — $HOME
+ * and everything above it — keeps exactly the mode the user configured; silently
+ * widening those would be a worse bug than the one being fixed.
+ */
+export async function mkdirUsable(target: string): Promise<void> {
+  if (process.platform === "win32") {
+    await mkdir(target, { recursive: true, mode: MANAGED_DIR_MODE });
+    return;
+  }
+  const segments = target.split(sep).filter(Boolean);
+  let current = isAbsolute(target) ? "" : ".";
+  for (const segment of segments) {
+    current = current === "" ? `${sep}${segment}` : `${current}${sep}${segment}`;
+    try {
+      await mkdir(current, { mode: MANAGED_DIR_MODE });
+    } catch (error) {
+      if (isErrno(error, "EEXIST")) continue;   // not ours — do not touch its mode
+      throw error;
+    }
+    await repairOwnerAccess(current, (await lstat(current)).mode);
+  }
+}
+
+/**
+ * Synchronous twin of {@link mkdirUsable}, for callers on a sync path.
+ *
+ * The config DB's parent is created before any await is possible, and it holds
+ * the entitlement snapshot, so it needs the same umask defeat and the same
+ * private mode. Kept beside the async version deliberately: two implementations
+ * of this rule in different files is how one of them ends up wrong.
+ */
+export function mkdirUsableSync(target: string): void {
+  if (process.platform === "win32") {
+    mkdirSync(target, { recursive: true, mode: MANAGED_DIR_MODE });
+    return;
+  }
+  const segments = target.split(sep).filter(Boolean);
+  let current = isAbsolute(target) ? "" : ".";
+  for (const segment of segments) {
+    current = current === "" ? `${sep}${segment}` : `${current}${sep}${segment}`;
+    try {
+      mkdirSync(current, { mode: MANAGED_DIR_MODE });
+    } catch (error) {
+      if (isErrno(error, "EEXIST")) continue;   // not ours — do not touch its mode
+      throw error;
+    }
+    if ((lstatSync(current).mode & MANAGED_DIR_MODE) !== MANAGED_DIR_MODE) {
+      chmodSync(current, MANAGED_DIR_MODE);
+    }
+  }
+}

--- a/tests/skill-manifest-sync.test.ts
+++ b/tests/skill-manifest-sync.test.ts
@@ -163,7 +163,55 @@ describe("subscription-tier skill manifest sync", () => {
     }
   });
 
-    // POSIX-only. Found by adversarial review of the FIRST fix: repairing a
+    it.skipIf(process.platform === "win32")("advances the materialized generation only when files actually land", async () => {
+    // THE CLASS, not a cause: the DB half commits before the file half by
+    // design (committed names drive offline pruning after a crash), so any
+    // materialization failure leaves the DB claiming a generation no file
+    // ever reached. This durable marker is how the next startup can SEE that
+    // divergence instead of trusting "unchanged" for nine days.
+    const agentsSkillsDir = await root();
+    const applied: Array<Record<string, string>> = [];
+    const applyManifest = vi.fn(async (state: { generation: string }) => {
+      applied.push({ generation: state.generation });
+    });
+    // A UNIQUE paid skill so this manifest's generation differs from every
+    // other test's: the config DB is per-process, not per-test, and the
+    // deterministic default generation was already recorded as materialized by
+    // an earlier successful sync in this file — which made the "did not
+    // advance" assertion vacuously false. Caught when the file ran as a whole
+    // after passing in isolation.
+    const snapshot = manifest("enterprise", ["marker-divergence-probe"]);
+    expect(await getSetting("skill_manifest:materialized_generation", ""))
+      .not.toBe(snapshot.generation);
+
+    // Fail AFTER the DB commit, which is the split this marker exists to
+    // expose. A broken root fails at the lock, BEFORE fetch and DB apply --
+    // reviewing this very test caught that wrong shape -- so the failure is
+    // injected at native staging instead, which runs after dbApplied = true.
+    const failed = await synchronizeSkillManifest({
+      agentsSkillsDir, claudeCodeSkillsDir: false, cursorSkillsDir: false,
+      applyManifest,
+      fetchImpl: vi.fn(() => jsonResponse(snapshot)) as unknown as typeof fetch,
+      beforeNativeStage: async () => { throw new Error("injected materialization failure"); },
+      ...paidAuth,
+    });
+    expect(failed.status).toBe("partial");
+    expect(applied.length).toBe(1);                     // DB half DID commit
+    expect(await getSetting("skill_manifest:materialized_generation", ""))
+      .not.toBe(snapshot.generation);                   // file half did NOT
+
+    const good = await synchronizeSkillManifest({
+      agentsSkillsDir, claudeCodeSkillsDir: false, cursorSkillsDir: false,
+      applyManifest,
+      fetchImpl: vi.fn(() => jsonResponse(snapshot)) as unknown as typeof fetch,
+      ...paidAuth,
+    });
+    expect(good.status).toBe("applied");
+    expect(await getSetting("skill_manifest:materialized_generation", ""))
+      .toBe(snapshot.generation);
+  });
+
+  // POSIX-only. Found by adversarial review of the FIRST fix: repairing a
   // pre-existing directory does nothing about a umask that is STILL restrictive,
   // because mkdtemp and every nested mkdir then create fresh untraversable
   // directories. The reviewer reproduced the original split-commit against the

--- a/tests/skill-manifest-sync.test.ts
+++ b/tests/skill-manifest-sync.test.ts
@@ -163,7 +163,36 @@ describe("subscription-tier skill manifest sync", () => {
     }
   });
 
-    // POSIX-only: Windows chmod maps to the read-only attribute alone and lstat
+    // POSIX-only. Found by adversarial review of the FIRST fix: repairing a
+  // pre-existing directory does nothing about a umask that is STILL restrictive,
+  // because mkdtemp and every nested mkdir then create fresh untraversable
+  // directories. The reviewer reproduced the original split-commit against the
+  // rebuilt dist -- DB committed, disk ENOENT -- through a repaired transaction
+  // base containing a brand-new unusable txn-* directory.
+  it.skipIf(process.platform === "win32")("materializes under a persistent umask that strips owner-execute", async () => {
+    // The temp base is made BEFORE the umask changes: root() is harness, not the
+    // code under test. Everything below it is created by the sync itself while
+    // the restrictive umask is active, which is the real scenario.
+    const base = await root();
+    const previous = process.umask(0o177);   // every mkdir/mkdtemp lands 0o600
+    try {
+      const agentsSkillsDir = join(base, "nested", "skills");   // ancestors must be created too
+      const result = await synchronizeSkillManifest({
+        agentsSkillsDir, claudeCodeSkillsDir: false, cursorSkillsDir: false,
+        applyManifest: vi.fn(async () => undefined),
+        fetchImpl: vi.fn(() => jsonResponse(manifest("enterprise", ["enterprise-skill"]))) as unknown as typeof fetch,
+        ...paidAuth,
+      });
+      expect(result.error).toBeFalsy();
+      expect(result.status).toBe("applied");
+      expect(await readFile(join(agentsSkillsDir, "prism-startup", "SKILL.md"), "utf8"))
+        .toContain("name: prism-startup");
+    } finally {
+      process.umask(previous);
+    }
+  });
+
+  // POSIX-only: Windows chmod maps to the read-only attribute alone and lstat
   // reports 0o666 for every writable directory, so a directory that cannot be
   // entered has no Windows analogue and the mode assertion is meaningless
   // there. Ran red on windows-latest with "expected 438 to be 448" before this.

--- a/tests/usable-directory.test.ts
+++ b/tests/usable-directory.test.ts
@@ -1,0 +1,121 @@
+import { chmod, lstat, mkdir, mkdtemp, readdir, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  MANAGED_DIR_MODE, mkdirUsable, mkdirUsableSync, repairOwnerAccess,
+} from "../src/utils/usableDirectory.js";
+
+/**
+ * These pin the properties the nine-day outage and its two follow-up reviews
+ * turned up. Every one is POSIX-specific: Windows has no permission bits to
+ * strip, so the failure being defended against cannot occur there.
+ */
+const roots: string[] = [];
+afterEach(async () => {
+  while (roots.length) {
+    const dir = roots.pop()!;
+    try { await chmod(dir, 0o700); } catch { /* best effort before removal */ }
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+async function root(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "usable-dir-"));
+  roots.push(dir);
+  return dir;
+}
+
+const posix = it.skipIf(process.platform === "win32");
+const mode = async (path: string) => (await lstat(path)).mode & 0o777;
+
+describe("usable directory creation", () => {
+  posix("creates every level enterable under a umask that strips owner-execute", async () => {
+    const base = await root();
+    const previous = process.umask(0o177);
+    try {
+      const deep = join(base, "a", "b", "c");
+      await mkdirUsable(deep);
+      for (const path of [join(base, "a"), join(base, "a", "b"), deep]) {
+        expect(await mode(path), path).toBe(MANAGED_DIR_MODE);
+      }
+      // Enterable in practice, not merely by mode arithmetic.
+      await writeFile(join(deep, "probe"), "ok");
+      expect(await readdir(deep)).toContain("probe");
+    } finally {
+      process.umask(previous);
+    }
+  });
+
+  posix("never alters a pre-existing ancestor's mode", async () => {
+    // The dangerous failure mode of this helper: silently widening $HOME or any
+    // directory the user configured deliberately. It may only touch what it makes.
+    const base = await root();
+    const existing = join(base, "shared");
+    await mkdir(existing, { mode: 0o755 });
+    await chmod(existing, 0o755);
+
+    const previous = process.umask(0o177);
+    try {
+      await mkdirUsable(join(existing, "child"));
+      expect(await mode(existing)).toBe(0o755);            // untouched
+      expect(await mode(join(existing, "child"))).toBe(MANAGED_DIR_MODE);
+    } finally {
+      process.umask(previous);
+    }
+  });
+
+  posix("mkdirUsableSync matches the async helper", async () => {
+    const base = await root();
+    const previous = process.umask(0o177);
+    try {
+      const deep = join(base, "x", "y");
+      mkdirUsableSync(deep);
+      expect(await mode(deep)).toBe(MANAGED_DIR_MODE);
+      expect(await mode(join(base, "x"))).toBe(MANAGED_DIR_MODE);
+    } finally {
+      process.umask(previous);
+    }
+  });
+});
+
+describe("owner-access repair", () => {
+  posix("repairs an unenterable directory to exactly 0o700", async () => {
+    const base = await root();
+    const target = join(base, "broken");
+    await mkdir(target, { mode: 0o700 });
+    await chmod(target, 0o606);                  // owner rw, no owner-x, other rw
+
+    await repairOwnerAccess(target, (await lstat(target)).mode);
+    // Not 0o706: OR-ing owner bits onto the existing mode would leave a
+    // directory holding entitled content readable by every other user.
+    expect(await mode(target)).toBe(MANAGED_DIR_MODE);
+  });
+
+  posix("leaves a usable group-shared directory alone", async () => {
+    // 0o770 is conventional sharing and the owner can already use it, so the
+    // repair must not fire and must not narrow it to 0o700.
+    const base = await root();
+    const target = join(base, "shared");
+    await mkdir(target, { mode: 0o770 });
+    await chmod(target, 0o770);
+
+    await repairOwnerAccess(target, (await lstat(target)).mode);
+    expect(await mode(target)).toBe(0o770);
+  });
+
+  posix("refuses to chmod through a symlink", async () => {
+    // The repair acts on an open descriptor rather than the pathname, so a path
+    // that resolves to something other than a directory cannot be used to
+    // redirect the permission change onto another object.
+    const base = await root();
+    const victim = join(base, "victim");
+    await writeFile(victim, "not a directory");
+    await chmod(victim, 0o644);
+    const link = join(base, "link");
+    await symlink(victim, link);
+
+    await expect(repairOwnerAccess(link, 0o000)).rejects.toThrow(/not a directory/);
+    expect(await mode(victim)).toBe(0o644);      // unchanged
+  });
+});

--- a/tests/usable-directory.test.ts
+++ b/tests/usable-directory.test.ts
@@ -104,6 +104,34 @@ describe("owner-access repair", () => {
     expect(await mode(target)).toBe(0o770);
   });
 
+  posix("repairs an unreadable directory the descriptor path cannot open", async () => {
+    // 0o000 lacks owner-read, so open() fails and only the guarded pathname
+    // fallback can fix it -- the corner the fallback exists for.
+    const base = await root();
+    const target = join(base, "sealed");
+    await mkdir(target, { mode: 0o700 });
+    await chmod(target, 0o000);
+    await repairOwnerAccess(target, 0o000);
+    expect(await mode(target)).toBe(MANAGED_DIR_MODE);
+  });
+
+  posix("refuses a symlink to an UNREADABLE target", async () => {
+    // The proven attack against the first descriptor-based version: open()
+    // fails on an unreadable target, and an unguarded pathname fallback then
+    // chmods THROUGH the link -- the victim ended up 0o700. Reproduced live
+    // against the built helper during review before this guard existed.
+    const base = await root();
+    const victim = join(base, "victim");
+    await writeFile(victim, "sealed");
+    await chmod(victim, 0o000);
+    const link = join(base, "link");
+    await symlink(victim, link);
+
+    await expect(repairOwnerAccess(link, 0o000)).rejects.toThrow(/not a directory/);
+    expect(await mode(victim)).toBe(0o000);      // unchanged
+    await chmod(victim, 0o600);                  // let cleanup remove it
+  });
+
   posix("refuses to chmod through a symlink", async () => {
     // The repair acts on an open descriptor rather than the pathname, so a path
     // that resolves to something other than a directory cannot be used to


### PR DESCRIPTION
Follow-up to #142, from an adversarial review that found it fixed the symptom and left the cause.

## What #142 missed

#142 repairs a directory that is **already** unusable. It does nothing about a umask that is **still** restrictive, because every directory created afterwards is masked the same way. The reviewer reproduced the original split-commit against the rebuilt `dist`:

```
status: "partial"
error:  "config DB applied; native materialization incomplete:
         EACCES ... .prism-skill-transactions/txn-.../stage"
dbCalls: 1
diskState: "ENOENT"
```

A repaired transaction base, containing a brand-new unusable `txn-*` directory. Same outage, one level deeper.

## Two uncovered creation paths

1. **`mkdtemp` is umask-masked** and nothing ever revisits its result, so the transaction root landed unenterable directly below the base #142 had just repaired.
2. **`mkdir(..., { recursive: true })` applies the masked mode to every level it creates**, so the first new ancestor is already untraversable and the call fails partway with EACCES before any repair can run. A fresh hierarchy failed outright: `EACCES: mkdir '.../.agents/skills'`.

## The fix

Node exposes no per-call umask, so `mkdirUsable` creates level by level and chmods what it just made. It repairs **only directories it creates** — a pre-existing ancestor (`$HOME` and above) keeps the mode the user chose, because silently widening those would be worse than the bug being fixed. All six creation sites route through it, including staged skill directories and their nested file directories.

## Verification

The regression test holds the umask restrictive for the **whole sync** rather than pre-breaking one directory, and asserts files actually reach disk. Verified to fail on merged `main`:

```
→ expected 'EACCES: permission denied, mkdir ...' to be falsy
```

Full suite **3812 passed**, build clean.

## What this does NOT close

The DB half still commits before materialization — `dbApplied = true` precedes the native loop — so **any** materialization failure (chmod `EPERM`, a full disk) still leaves the client reporting a generation it never wrote. That is the failure *class*; this PR removes one more cause of it. Reordering the commit, or surfacing `partial` where a human actually sees it, is the real mitigation and is not attempted here.