### PR TITLE
fix(skills): render the STALE warning where truncation cannot reach it

### DIFF
--- a/src/tools/ledgerHandlers.ts
+++ b/src/tools/ledgerHandlers.ts
@@ -398,6 +398,12 @@ async function buildNativeSystemReadyBlock(
   // frozen from an earlier failed materialization. This line is the difference
   // between that outage being visible on the next startup and it running for
   // nine days.
+  //
+  // Rendered directly UNDER the header, never appended at the tail:
+  // capNativeStartupText keeps the head and cuts the tail, so a tail-placed
+  // warning is the first thing truncated at capped depths -- observed live in
+  // the divergence simulation (STALE was line 19 of 20). The most important
+  // line goes where truncation cannot reach it.
   const undeliveredWarning = snapshot.undeliveredGeneration
     ? `\n> - ⚠️ **Skill files are STALE:** the entitlement DB is at generation ` +
       `\`${snapshot.undeliveredGeneration.slice(0, 12)}…\` but its files never finished ` +
@@ -405,7 +411,7 @@ async function buildNativeSystemReadyBlock(
       `(restart the host or \`prism connect\`) and report this if it persists.`
     : "";
   if (snapshot.source === "validated-partial") {
-    return `> **Prism System Ready**\n>\n` +
+    return `> **Prism System Ready**\n>` + undeliveredWarning + `\n` +
       `> - 🪪 **Subscription tier:** ${snapshot.tier}\n` +
       `> - 📦 **Entitled skills (materialization incomplete):** ${snapshot.names.length}\n` +
       `> - 📚 **Core/protected entitlements:** ${formatBoundedSkillNames(coreSkills, "entitled")}\n` +
@@ -413,19 +419,19 @@ async function buildNativeSystemReadyBlock(
       `> - 🛠️ **Other tier entitlements:** ${formatBoundedSkillNames(otherTierSkills, "entitled")}\n` +
       `> - 🧠 **Context depth:** ${depth}\n` +
       `> - 🔄 **Skill sync:** ${SKILL_SYNC_STATUS_LABELS[snapshot.syncStatus]} · native materialization incomplete${conflictSuffix}` +
-      conflictWarning + undeliveredWarning +
+      conflictWarning +
       freeTierUpgradeLine(snapshot.tier);
   }
   if (snapshot.source === "tier-fallback") {
-    return `> **Prism System Ready**\n>\n` +
+    return `> **Prism System Ready**\n>` + undeliveredWarning + `\n` +
       `> - 🪪 **Subscription tier:** ${snapshot.tier}\n` +
       `> - 🛡️ **Fallback skill names:** ${formatBoundedSkillNames(snapshot.names, "fallback")}\n` +
       `> - 🧠 **Context depth:** ${depth}\n` +
       `> - 🔄 **Skill sync:** ${SKILL_SYNC_STATUS_LABELS[snapshot.syncStatus]} · no committed manifest${conflictSuffix}` +
-      conflictWarning + undeliveredWarning +
+      conflictWarning +
       freeTierUpgradeLine(snapshot.tier);
   }
-  return `> **Prism System Ready**\n>\n` +
+  return `> **Prism System Ready**\n>` + undeliveredWarning + `\n` +
     `> - 🪪 **Subscription tier:** ${snapshot.tier}\n` +
     `> - 📦 **Provisioned skills:** ${snapshot.names.length}\n` +
     `> - 📚 **Core/protected skills provisioned:** ${formatBoundedSkillNames(coreSkills, "provisioned")}\n` +
@@ -433,7 +439,7 @@ async function buildNativeSystemReadyBlock(
     `> - 🛠️ **Other tier skills provisioned:** ${formatBoundedSkillNames(otherTierSkills, "provisioned")}\n` +
     `> - 🧠 **Context depth:** ${depth}\n` +
     `> - 🔄 **Skill sync:** ${SKILL_SYNC_STATUS_LABELS[snapshot.syncStatus]} · committed manifest${conflictSuffix}` +
-    conflictWarning + undeliveredWarning +
+    conflictWarning +
     freeTierUpgradeLine(snapshot.tier);
 }
 

--- a/tests/tools/ledgerHandlers.test.ts
+++ b/tests/tools/ledgerHandlers.test.ts
@@ -1038,6 +1038,52 @@ describe("ledgerHandlers", () => {
       else process.env.PRISM_DASHBOARD_PORT = savedDashboardPort;
     });
 
+    it("renders the STALE warning under the header when a committed generation never materialized", async () => {
+      // The 2026-08-10 outage's visibility fix. Two properties, both learned
+      // the hard way in the live simulation:
+      //  - it must FIRE on divergence (DB committed generation A, files only
+      //    ever reached B), because "unchanged" syncs kept that state
+      //    invisible for nine days;
+      //  - it must sit directly UNDER the header, because
+      //    capNativeStartupText keeps the head and cuts the tail, and the
+      //    first version appended it at the tail -- line 19 of 20 -- exactly
+      //    where capped depths truncate first.
+      mockGetSetting.mockImplementation(async (key: string, fallback = "") => ({
+        "skill_manifest:tier": "enterprise",
+        "skill_manifest:names": JSON.stringify(["aba-precision-protocol"]),
+        "skill_manifest:generation": "a".repeat(64),
+        "skill_manifest:materialized_generation": "b".repeat(64),
+      }[key] ?? fallback));
+
+      const result = await sessionBootstrapHandler({});
+      const text = result.content[0].text as string;
+      const lines = text.split("\n");
+      const ready = lines.findIndex((line) => line.includes("Prism System Ready"));
+      const stale = lines.findIndex((line) => line.includes("Skill files are STALE"));
+      expect(stale).toBeGreaterThan(-1);
+      expect(ready).toBeGreaterThan(-1);
+      expect(stale).toBeLessThanOrEqual(ready + 2);
+      expect(text).toContain("aaaaaaaaaaaa…");
+    });
+
+    it("stays silent when generations match and when the marker was never recorded", async () => {
+      // Convergence = healthy. Empty marker = pre-marker install or an offline
+      // failed fetch on upgrade day -- warning must NOT fire, because a false
+      // alarm trains people to ignore the line that matters.
+      for (const materialized of ["a".repeat(64), ""]) {
+        mockGetSetting.mockImplementation(async (key: string, fallback = "") => ({
+          "skill_manifest:tier": "enterprise",
+          "skill_manifest:names": JSON.stringify(["aba-precision-protocol"]),
+          "skill_manifest:generation": "a".repeat(64),
+          "skill_manifest:materialized_generation": materialized,
+        }[key] ?? fallback));
+
+        const result = await sessionBootstrapHandler({});
+        const text = result.content[0].text as string;
+        expect(text, `materialized=${JSON.stringify(materialized)}`).not.toContain("Skill files are STALE");
+      }
+    });
+
     it("greets a first run with actions and the paid CTA, never with absence", async () => {
       // First run = dashboard never touched: no agent identity, no projects,
       // no prior bootstrap marker.


### PR DESCRIPTION
Found by running the divergence simulation the #143 review asked for.

## The simulation, and what it caught

Sandboxed config DB (`PRISM_CONFIG_PATH`), seeded with the outage shape verbatim — committed generation `aaa…`, materialized `bbb…` — then the real `sessionBootstrapHandler` run against the built `dist`.

Three runs, three lessons:

1. **First two runs: the warning didn't fire — because the system healed itself.** Shell env leaked real portal credentials into the sandbox, the sync succeeded, overwrote the seeded divergence, advanced the marker. Annoying for the simulation; exactly right in production. The healing path got verified twice by accident.
2. **Credentials scrubbed, sync failing: the warning fired, verbatim, naming the generation** — as line **19 of 20**.
3. `capNativeStartupText` keeps the head and **cuts the tail**, with `quick` capped at 4,000 chars. A 97-skill banner exceeds that. The most important line in the banner was positioned to be the first thing truncated. Appending a warning last is the same mistake as logging `partial` to stderr: technically emitted, practically invisible.

## The fix

The warning renders directly under the `Prism System Ready` header in all three display branches. Re-run end-to-end in the sandbox: STALE at header+2 with the generation named, gone after reconvergence.

## Tests

- Placement pinned: fails against the tail-placed version with `expected 15 to be <= 8`
- Silence pinned for both convergence **and** a never-recorded marker — an empty marker is a pre-marker install or an offline upgrade-day fetch failure, and a false alarm trains people to ignore the line that matters

Full suite **3823 passed**, build clean.