### PR TITLE
fix(skills): the display reads the marker through the writer's constant

### DIFF
--- a/src/tools/ledgerHandlers.ts
+++ b/src/tools/ledgerHandlers.ts
@@ -32,7 +32,7 @@ import { toKeywordArray } from "../utils/keywordExtractor.js";
 import { getLLMProvider } from "../utils/llm/factory.js";
 import { getCurrentGitState, getGitDrift } from "../utils/git.js";
 import { getSetting, setSetting, getAllSettings, refreshConfigStorageCache } from "../storage/configStorage.js";
-import type { SkillSyncResult } from "../skillManifestSync.js";
+import { MATERIALIZED_GENERATION_KEY, type SkillSyncResult } from "../skillManifestSync.js";
 import { mergeHandoff, dbToHandoffSchema, sanitizeForMerge } from "../utils/crdtMerge.js";
 import { resolveProject } from "../utils/projectResolver.js";
 import type { StorageBackend } from "../storage/interface.js";
@@ -281,7 +281,11 @@ async function resolveNativeSkillManifestSnapshot(
       getSetting("skill_manifest:names", "[]"),
       getSetting("skill_manifest:tier", ""),
       getSetting("skill_manifest:generation", ""),
-      getSetting("skill_manifest:materialized_generation", ""),
+      // The exported constant, not a copied literal: a key rename on either
+      // side would otherwise leave this read returning "" forever -- warning
+      // permanently silent -- with both sides' tests still green, because each
+      // asserts against its own copy of the string.
+      getSetting(MATERIALIZED_GENERATION_KEY, ""),
     ]);
   // The DB half of a sync commits before files are written, by design: the
   // committed names are what let a crashed run prune obsolete skills offline on

--- a/tests/tools/ledgerHandlers.test.ts
+++ b/tests/tools/ledgerHandlers.test.ts
@@ -47,6 +47,11 @@ vi.mock("../../src/storage/configStorage.js", () => ({
 }));
 
 vi.mock("../../src/skillManifestSync.js", () => ({
+  // The handler imports this constant as a VALUE. A mock that omits it hands
+  // the display code `undefined` as its settings key, which silently disables
+  // the STALE warning in every test — 69 failures traced to exactly that when
+  // the import changed from type-only to value.
+  MATERIALIZED_GENERATION_KEY: "skill_manifest:materialized_generation",
   awaitSkillManifestSync: vi.fn(() => Promise.resolve({
     status: "unchanged",
     installed: [],


### PR DESCRIPTION
Adversarial review of the merged visibility chain (#142–#144), attacking what previous rounds had not.

## The finding

`skillManifestSync` exports `MATERIALIZED_GENERATION_KEY`; the display read the same key as a **copied string literal**. A rename on either side would leave the read returning `""` forever — the STALE warning permanently silent — with both sides' tests still green, because each asserts against its own copy of the string. That's the exact shape of drift this warning exists to expose, one level up. The reader now imports the writer's constant: production cannot drift by construction.

The one-line import broke **69 tests** before the fix landed: the test file mocks `skillManifestSync` wholesale, the old import was type-only (erased at runtime), and a mock that omits the newly-imported *value* hands the display `undefined` as its settings key — silently disabling the warning in every test. The mock now exports the constant. A type-to-value import change across a mocked module boundary is invisible until runtime.

## Verified non-findings from the same review

- **Bootstrap truncation is double-covered**: the loading budget subtracts `systemReadyBlock.length` up front (reservation), and the warning sits under the header inside the block (#144).
- **`session_load_context` renders no ready block at all — by design.** Bootstrap is mandatory on the first turn of every conversation, so the warning's surface is every session start.
- **`mkdirUsableSync` asymmetry accepted**: it repairs freshly-created directories via pathname chmod without the async twin's `O_NOFOLLOW` descriptor path. The window is a directory this process created microseconds earlier inside the user's home; documented rather than silently differing.

Full suite **3823 passed**, build clean.