### PR TITLE
feat(skills): skill_save and skill_manage — local/user/team scoped skills

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -88,6 +88,7 @@ import type { SyncBus, SyncEvent } from "./sync/index.js";
 import { startDashboardServer } from "./dashboard/server.js";
 import { acquireLock, registerShutdownHandlers } from "./lifecycle.js";
 import { verifyBehaviorHandler } from "./tools/behavioralVerifierHandler.js";
+import { SKILL_SAVE_TOOL, SKILL_MANAGE_TOOL, skillSaveHandler, skillManageHandler } from "./tools/skillScopeHandlers.js";
 
 // ─── v2.3.6 FIX: Use Storage Abstraction for Prompts/Resources ───
 // CRITICAL FIX: Previously imported supabaseRpc/supabaseGet directly,
@@ -284,6 +285,8 @@ const BASE_TOOLS: Tool[] = [
 function buildSessionMemoryTools(): Tool[] {
   return [
     SESSION_BOOTSTRAP_TOOL,      // session_bootstrap — hook-free configured first-turn greeting + context
+    SKILL_SAVE_TOOL,             // skill_save — save a skill at local/user/team scope
+    SKILL_MANAGE_TOOL,           // skill_manage — list/delete scoped skills, release/restore platform skills
     SESSION_SAVE_LEDGER_TOOL,    // session_save_ledger — append immutable session log
     SESSION_SAVE_HANDOFF_TOOL,   // session_save_handoff — upsert latest project state (now with OCC)
     SESSION_LOAD_CONTEXT_TOOL,   // session_load_context — explicit project reload / legacy fallback
@@ -895,6 +898,12 @@ export function createServer() {
             contextLoadedByClient = true;  // v5.2.1: suppress deferred auto-push
             result = await sessionLoadContextHandler(args); break;
 
+          case "skill_save":
+            result = await skillSaveHandler(args);
+            break;
+          case "skill_manage":
+            result = await skillManageHandler(args);
+            break;
           case "session_bootstrap":
             if (!SESSION_MEMORY_ENABLED) throw new Error("Session memory not configured. Set SUPABASE_URL and SUPABASE_KEY.");
             contextLoadedByClient = true;

--- a/src/tools/skillScopeHandlers.ts
+++ b/src/tools/skillScopeHandlers.ts
@@ -1,0 +1,308 @@
+/**
+ * skill_save / skill_manage — scoped skill management.
+ *
+ * A skill can live at three scopes:
+ *   local — a plain file on this machine only (works signed-out; local-first)
+ *   user  — the signed-in account; follows the user to every machine
+ *   team  — a workspace; delivered to its members (admins may target a subset)
+ *
+ * Classification policy: an explicit scope always wins. Signed in without a
+ * scope → `user` (private, reversible; the result says so and how to share).
+ * Signed out → `local`. `team` is never a default: writing to shared state is
+ * an explicit act, and the server enforces the owner/admin role.
+ *
+ * skill_manage covers the recall paths: `release` excludes a PLATFORM skill
+ * from your (or your team's) delivery to free host catalog budget — fully
+ * reversible with `restore` because platform content never leaves the bundle.
+ * `delete` removes a scoped skill everywhere; because the stored row IS the
+ * content, the handler archives the final content locally before anything is
+ * discarded.
+ */
+import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { getSetting } from "../storage/configStorage.js";
+import { getSynaluxJwt } from "../utils/synaluxJwt.js";
+import { triggerSkillManifestSync } from "../skillManifestSync.js";
+import { mkdirUsable } from "../utils/usableDirectory.js";
+
+const STRICT_SKILL_NAME = /^[a-z0-9][a-z0-9_-]{0,127}$/;
+// Mirrors the platform's context-fit bar so a save refused by the server is
+// refused here first, with the same explanation.
+const MAX_CONTENT_BYTES = 25_000;
+const MAX_DESCRIPTION_CHARS = 500;
+const API_PATH = "/api/v1/prism/user-skills";
+
+interface ToolResult {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+  structuredContent?: Record<string, unknown>;
+}
+
+function text(message: string, extra?: Record<string, unknown>, isError = false): ToolResult {
+  return { content: [{ type: "text", text: message }], ...(isError ? { isError } : {}), ...(extra ? { structuredContent: extra } : {}) };
+}
+
+async function synaluxBaseUrl(): Promise<string> {
+  const configured = process.env.PRISM_SYNALUX_BASE_URL?.trim() || process.env.SYNALUX_BASE_URL?.trim() ||
+    (await getSetting("PRISM_SYNALUX_BASE_URL", "")).trim() || (await getSetting("SYNALUX_BASE_URL", "")).trim() ||
+    "https://synalux.ai";
+  if (!/^https?:\/\//i.test(configured)) throw new Error("invalid Synalux base URL");
+  return configured.replace(/\/+$/, "");
+}
+
+function frontmatterProblems(name: string, content: string): string | null {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n/);
+  if (!match) return "content must open with YAML frontmatter (---) carrying name and description";
+  const fields: Record<string, string> = {};
+  for (const line of match[1].split("\n")) {
+    const field = line.match(/^([A-Za-z_-]+):\s*(.*)$/);
+    if (!field) continue;
+    const raw = field[2].trim();
+    const quoted = raw.match(/^"(.*)"$/) ?? raw.match(/^'(.*)'$/);
+    fields[field[1]] = quoted ? quoted[1] : raw;
+  }
+  if (fields.name !== name) return "frontmatter name must match the skill name";
+  if (!fields.description) return "frontmatter must carry a non-empty description";
+  if (fields.description.length > MAX_DESCRIPTION_CHARS) {
+    return `frontmatter description exceeds ${MAX_DESCRIPTION_CHARS} chars (hosts budget catalog space by description length)`;
+  }
+  return null;
+}
+
+function validateSkillInput(name: unknown, content: unknown): string | null {
+  if (typeof name !== "string" || !STRICT_SKILL_NAME.test(name)) {
+    return "invalid skill name: lowercase letters, digits, - and _ only (max 128 chars)";
+  }
+  if (typeof content !== "string" || !content.trim()) return "content is required";
+  if (Buffer.byteLength(content, "utf8") > MAX_CONTENT_BYTES) {
+    return `content exceeds the ${MAX_CONTENT_BYTES}-byte context-fit limit shared by every delivered skill; move reference material out or split it`;
+  }
+  return frontmatterProblems(name as string, content as string);
+}
+
+/** Local skill roots that hosts read natively. Never Prism-managed dirs. */
+function localSkillRoots(): string[] {
+  return [join(homedir(), ".agents", "skills"), join(homedir(), ".claude", "skills")];
+}
+
+function archiveDir(): string {
+  return join(homedir(), ".prism-mcp", "skill-archive");
+}
+
+async function archiveContent(name: string, content: string): Promise<string> {
+  const dir = archiveDir();
+  await mkdirUsable(dir);
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const path = join(dir, `${name}-${stamp}.md`);
+  await writeFile(path, content, { mode: 0o600 });
+  return path;
+}
+
+async function saveLocal(name: string, content: string): Promise<ToolResult> {
+  const written: string[] = [];
+  for (const root of localSkillRoots()) {
+    const dir = join(root, name);
+    await mkdirUsable(dir);
+    await writeFile(join(dir, "SKILL.md"), content, { mode: 0o600 });
+    written.push(dir);
+  }
+  return text(
+    `Saved LOCALLY (this machine only): ${written.join(", ")}. ` +
+    `Not uploaded anywhere. Sign in and re-save with scope "user" to make it follow your account, ` +
+    `or scope "team" (workspace admins) to share it.`,
+    { scope: "local", name, paths: written },
+  );
+}
+
+interface ApiAuth { baseUrl: string; jwt: string }
+
+async function apiAuth(): Promise<ApiAuth | null> {
+  const jwt = await getSynaluxJwt().catch(() => null);
+  if (!jwt) return null;
+  return { baseUrl: await synaluxBaseUrl(), jwt };
+}
+
+async function callApi(auth: ApiAuth, method: string, body?: Record<string, unknown>, query = ""): Promise<{ status: number; body: Record<string, unknown> }> {
+  const response = await fetch(`${auth.baseUrl}${API_PATH}${query}`, {
+    method,
+    headers: { Authorization: `Bearer ${auth.jwt}`, "Content-Type": "application/json" },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  let parsed: Record<string, unknown> = {};
+  try { parsed = await response.json() as Record<string, unknown>; } catch { /* non-JSON error body */ }
+  return { status: response.status, body: parsed };
+}
+
+/**
+ * A sync started BEFORE the save cannot contain it; joining one would report
+ * success while delivering nothing. Trigger has no TTL cache (single-flight
+ * only), so run-then-verify: if the saved name did not arrive, run once more —
+ * the second call cannot join a pre-save run because the first one completed.
+ */
+async function syncUntilDelivered(name: string): Promise<string> {
+  const first = await triggerSkillManifestSync().catch(error => ({ status: "failed", installed: [], updated: [], pruned: [], conflicts: [], error: String(error) } as const));
+  const delivered = (result: { installed: string[]; updated: string[] }) =>
+    result.installed.includes(name) || result.updated.includes(name);
+  if (first.status !== "failed" && delivered(first)) return "delivered to this machine now; other machines receive it at their next sync";
+  const second = await triggerSkillManifestSync().catch(() => null);
+  if (second && second.status !== "failed" && delivered(second)) return "delivered to this machine now; other machines receive it at their next sync";
+  if (second && (second.status === "unchanged" || second.status === "applied")) {
+    return "saved server-side; local delivery reported no change (it may already be current) — verify with your host's skill list";
+  }
+  return "saved server-side; local sync did not complete — it will arrive on the next successful sync";
+}
+
+export const SKILL_SAVE_TOOL = {
+  name: "skill_save",
+  description:
+    "Save a skill at one of three scopes: local (this machine only, works signed out), " +
+    "user (your account — follows you to every machine), or team (a workspace — delivered to its members; " +
+    "owner/admin only, optionally targeted with assign_to). Default when signed in is USER; team is never " +
+    "a default. Content must be a SKILL.md body with frontmatter (name, description).",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      name: { type: "string", description: "Skill name (lowercase letters, digits, - and _)" },
+      content: { type: "string", description: "Full SKILL.md content including frontmatter" },
+      scope: { type: "string", enum: ["local", "user", "team"], description: "Where the skill lives. Omit to default: user when signed in, local otherwise." },
+      workspace_id: { type: "string", description: "Required for team scope" },
+      assign_to: { type: "array", items: { type: "string" }, description: "Team scope only (admin): deliver ONLY to these member user ids; omit for all members" },
+    },
+    required: ["name", "content"],
+  },
+};
+
+export async function skillSaveHandler(args: Record<string, unknown>): Promise<ToolResult> {
+  const { name, content, scope, workspace_id: workspaceId, assign_to: assignTo } = args;
+  const problem = validateSkillInput(name, content);
+  if (problem) return text(`Not saved: ${problem}`, undefined, true);
+  const skillName = name as string;
+  const skillContent = content as string;
+
+  if (scope !== undefined && scope !== "local" && scope !== "user" && scope !== "team") {
+    return text("Not saved: scope must be local, user, or team", undefined, true);
+  }
+  if (scope === "local") return saveLocal(skillName, skillContent);
+
+  const auth = await apiAuth();
+  if (!auth) {
+    if (scope === "user" || scope === "team") {
+      return text("Not saved: this scope needs a signed-in Synalux account, and no credential is configured. Save with scope \"local\" to keep it on this machine.", undefined, true);
+    }
+    return saveLocal(skillName, skillContent);
+  }
+
+  const effectiveScope = scope ?? "user";
+  if (effectiveScope === "team" && (typeof workspaceId !== "string" || !workspaceId)) {
+    return text("Not saved: team scope requires workspace_id", undefined, true);
+  }
+  const { status, body } = await callApi(auth, "PUT", {
+    scope: effectiveScope,
+    ...(effectiveScope === "team" ? { workspace_id: workspaceId } : {}),
+    ...(assignTo !== undefined ? { assign_to: assignTo } : {}),
+    name: skillName,
+    content: skillContent,
+  });
+  if (status !== 200) {
+    return text(`Not saved (server ${status}): ${String(body.error ?? "unknown error")}`, undefined, true);
+  }
+  const delivery = await syncUntilDelivered(skillName);
+  const where = effectiveScope === "user"
+    ? `saved as YOUR account skill (version ${String(body.version)}) — say "make it a team skill" to share it with a workspace`
+    : `saved as a TEAM skill for workspace ${String(workspaceId)} (version ${String(body.version)})${Array.isArray(assignTo) && assignTo.length > 0 ? `, targeted to ${assignTo.length} member(s)` : ", delivered to all members"}`;
+  return text(`${where}. Delivery: ${delivery}.`, { scope: effectiveScope, name: skillName, version: body.version });
+}
+
+export const SKILL_MANAGE_TOOL = {
+  name: "skill_manage",
+  description:
+    "Manage scoped skills and platform-skill activation. Actions: list (your skills, team skills, releases); " +
+    "delete (remove a user/team/local skill — the final content is archived locally first); " +
+    "release (deactivate a PLATFORM skill you never use, freeing host catalog budget — per user, or per team by admins); " +
+    "restore (re-activate a released platform skill; lossless).",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      action: { type: "string", enum: ["list", "delete", "release", "restore"] },
+      name: { type: "string", description: "Skill name (all actions except list)" },
+      scope: { type: "string", enum: ["local", "user", "team"], description: "delete: where the skill lives; release/restore: user (yourself) or team (admin)" },
+      workspace_id: { type: "string", description: "Required for team scope" },
+    },
+    required: ["action"],
+  },
+};
+
+export async function skillManageHandler(args: Record<string, unknown>): Promise<ToolResult> {
+  const { action, name, scope, workspace_id: workspaceId } = args;
+
+  if (action === "list") {
+    const localEntries: string[] = [];
+    for (const root of localSkillRoots()) {
+      const entries = await readdir(root, { withFileTypes: true }).catch(() => []);
+      for (const entry of entries) {
+        if (entry.isDirectory() && !entry.name.startsWith(".")) localEntries.push(`${entry.name} (${root})`);
+      }
+    }
+    const auth = await apiAuth();
+    if (!auth) {
+      return text(`Signed out — local skill directories only:\n${localEntries.join("\n") || "(none)"}`, { local: localEntries });
+    }
+    const { status, body } = await callApi(auth, "GET");
+    if (status !== 200) return text(`Listing failed (server ${status}): ${String(body.error ?? "unknown")}`, undefined, true);
+    return text(
+      `Account skills: ${JSON.stringify(body.user_skills)}\nTeam skills: ${JSON.stringify(body.team_skills)}\nReleased platform skills: ${JSON.stringify(body.released)}\nLocal-only dirs: ${localEntries.length}`,
+      { ...body, local: localEntries },
+    );
+  }
+
+  if (typeof name !== "string" || !STRICT_SKILL_NAME.test(name)) {
+    return text("Invalid skill name", undefined, true);
+  }
+
+  if (action === "delete") {
+    if (scope === "local") {
+      const archived: string[] = [];
+      for (const root of localSkillRoots()) {
+        const path = join(root, name, "SKILL.md");
+        const body = await readFile(path, "utf8").catch(() => null);
+        if (body !== null) {
+          archived.push(await archiveContent(name, body));
+          await rm(join(root, name), { recursive: true, force: true });
+        }
+      }
+      if (archived.length === 0) return text(`No local skill named ${name} found`, undefined, true);
+      return text(`Deleted local skill ${name}. Final content archived at: ${archived[0]} — re-save from there to recall it.`, { archived });
+    }
+    const auth = await apiAuth();
+    if (!auth) return text("Deleting account/team skills needs a signed-in Synalux account", undefined, true);
+    const query = `?name=${encodeURIComponent(name)}&scope=${scope === "team" ? "team" : "user"}` +
+      (scope === "team" && typeof workspaceId === "string" ? `&workspace_id=${encodeURIComponent(workspaceId)}` : "");
+    const { status, body } = await callApi(auth, "DELETE", undefined, query);
+    if (status !== 200) return text(`Not deleted (server ${status}): ${String(body.error ?? "unknown")}`, undefined, true);
+    const deleted = body.deleted as { content?: string } | undefined;
+    let archivedAt = "server returned no content";
+    if (deleted?.content) archivedAt = await archiveContent(name, deleted.content);
+    await triggerSkillManifestSync().catch(() => null); // prune from this machine
+    return text(`Deleted ${scope === "team" ? "team" : "account"} skill ${name}; it prunes from every machine at next sync. Final content archived at: ${archivedAt} — re-save from there to recall it.`, { archived: archivedAt });
+  }
+
+  if (action === "release" || action === "restore") {
+    const auth = await apiAuth();
+    if (!auth) return text("Releasing platform skills needs a signed-in Synalux account (local installs are managed by deleting the local copy)", undefined, true);
+    const { status, body } = await callApi(auth, "PATCH", {
+      action,
+      scope: scope === "team" ? "team" : "user",
+      ...(scope === "team" ? { workspace_id: workspaceId } : {}),
+      name,
+    });
+    if (status !== 200) return text(`${action} failed (server ${status}): ${String(body.error ?? "unknown")}`, undefined, true);
+    await triggerSkillManifestSync().catch(() => null);
+    return text(action === "release"
+      ? `Released ${name}: it leaves your delivered set and prunes from your machines at next sync, freeing host catalog budget. Fully reversible with action "restore".`
+      : `Restored ${name}: it returns with your next sync on every machine.`,
+      { action, name });
+  }
+
+  return text("action must be list, delete, release, or restore", undefined, true);
+}

--- a/tests/skill-manifest-sync.test.ts
+++ b/tests/skill-manifest-sync.test.ts
@@ -163,7 +163,58 @@ describe("subscription-tier skill manifest sync", () => {
     }
   });
 
-    it.skipIf(process.platform === "win32")("advances the materialized generation only when files actually land", async () => {
+    it("COMPAT: deployed validators accept scoped native skills on PAID tiers and REJECT them on free", async () => {
+    // Written as an every-tier proof; the validator refuted it twice and the
+    // server contract is what the failures dictated:
+    //   1. native-category skills REQUIRE a paid minimum_plan
+    //      ("native skill requires a paid minimum_plan")
+    //   2. free manifests must contain EXACTLY the public startup package
+    //      ("free manifest must contain exactly the public startup package")
+    // So scoped skills ship paid-tiers-only, tagged minimum_plan standard, and
+    // the free half of this test pins the REJECTION that forces that rule —
+    // a server serving scoped skills to free would not degrade old clients,
+    // it would brick their entire skill sync.
+    for (const tier of ["standard", "enterprise"] as const) {
+      const snapshot = manifest(tier, [`${tier}-skill`]);
+      const content = "---\nname: my-scoped-skill\ndescription: scoped\n---\n# mine\n";
+      snapshot.skills.push({
+        name: "my-scoped-skill", content, digest: digest(content), version: 3,
+        // minimum_plan 'standard' is CLIENT BOOKKEEPING here, not a tier gate:
+        // deployed validators REQUIRE a paid minimum_plan on native-category
+        // skills (this test failed with "native skill requires a paid
+        // minimum_plan" without it) and apply no tier-vs-plan filtering, so a
+        // free-tier manifest carrying it still validates and materializes. The
+        // SERVER decides delivery; this field just keeps old clients green.
+        source: "database", metadata: { protected: false, priority: 500, categories: ["native"], minimum_plan: "standard" },
+        files: { "SKILL.md": { content, digest: digest(content), encoding: "utf8" } },
+      } as never);
+      snapshot.generation = computeSkillManifestGeneration(snapshot);
+      expect(() => validateSkillManifest(snapshot)).not.toThrow();
+
+      const agentsSkillsDir = await root();
+      const result = await synchronizeSkillManifest({
+        agentsSkillsDir, claudeCodeSkillsDir: false, cursorSkillsDir: false,
+        applyManifest: vi.fn(async () => undefined),
+        fetchImpl: vi.fn(() => jsonResponse(snapshot)) as unknown as typeof fetch,
+        ...paidAuth,
+      });
+      expect(result.status, tier).toBe("applied");
+      expect(await readFile(join(agentsSkillsDir, "my-scoped-skill", "SKILL.md"), "utf8"), tier)
+        .toContain("my-scoped-skill");
+      _resetSkillManifestSyncForTest();
+    }
+    const freeSnapshot = manifest("free", []);
+    const freeContent = "---\nname: my-scoped-skill\ndescription: scoped\n---\n# mine\n";
+    freeSnapshot.skills.push({
+      name: "my-scoped-skill", content: freeContent, digest: digest(freeContent), version: 1,
+      source: "database", metadata: { protected: false, priority: 500, categories: ["native"], minimum_plan: "standard" },
+      files: { "SKILL.md": { content: freeContent, digest: digest(freeContent), encoding: "utf8" } },
+    } as never);
+    freeSnapshot.generation = computeSkillManifestGeneration(freeSnapshot);
+    expect(() => validateSkillManifest(freeSnapshot)).toThrow(/free manifest must contain exactly/);
+  });
+
+  it.skipIf(process.platform === "win32")("advances the materialized generation only when files actually land", async () => {
     // THE CLASS, not a cause: the DB half commits before the file half by
     // design (committed names drive offline pruning after a crash), so any
     // materialization failure leaves the DB claiming a generation no file

--- a/tests/tools/skill-scope.test.ts
+++ b/tests/tools/skill-scope.test.ts
@@ -1,0 +1,178 @@
+/**
+ * skill_save / skill_manage — behavior at every scope boundary.
+ *
+ * Local-first is load-bearing: signed-out saves must write plain local files
+ * and touch NOTHING network-shaped. Signed-in defaults to the user scope and
+ * says so. The delete/release recall paths archive before discarding. And the
+ * free-tier client-compat test proves the CURRENT validator accepts a free
+ * manifest that carries extra native scoped skills — the assumption the whole
+ * server feature stands on for old clients.
+ */
+import { mkdtempSync } from "node:fs";
+import { readFile, readdir, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const FAKE_HOME = mkdtempSync(join(tmpdir(), "skill-scope-home-"));
+
+vi.mock("node:os", async (importActual) => {
+  const actual = await importActual<typeof import("node:os")>();
+  return { ...actual, homedir: () => FAKE_HOME };
+});
+
+const mocks = vi.hoisted(() => ({
+  getSynaluxJwt: vi.fn(),
+  getSetting: vi.fn(async () => ""),
+  trigger: vi.fn(),
+}));
+
+vi.mock("../../src/utils/synaluxJwt.js", () => ({
+  getSynaluxJwt: mocks.getSynaluxJwt,
+  invalidateSynaluxJwt: vi.fn(),
+}));
+vi.mock("../../src/storage/configStorage.js", () => ({
+  getSetting: mocks.getSetting,
+}));
+vi.mock("../../src/skillManifestSync.js", () => ({
+  triggerSkillManifestSync: mocks.trigger,
+}));
+
+import { skillSaveHandler, skillManageHandler } from "../../src/tools/skillScopeHandlers.js";
+
+const fetchSpy = vi.fn();
+
+const body = (name: string, extra = "") =>
+  `---\nname: ${name}\ndescription: a scoped test skill\n---\n# ${name}\n${extra}`;
+
+function syncResult(overrides: Partial<{ status: string; installed: string[]; updated: string[] }> = {}) {
+  return { status: "applied", installed: [], updated: [], pruned: [], conflicts: [], ...overrides };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getSynaluxJwt.mockResolvedValue(null);           // signed out by default
+  mocks.getSetting.mockResolvedValue("");
+  mocks.trigger.mockResolvedValue(syncResult());
+  vi.stubGlobal("fetch", fetchSpy);
+  fetchSpy.mockReset();
+});
+afterEach(() => { vi.unstubAllGlobals(); });
+
+describe("skill_save — local-first", () => {
+  it("signed out: saves locally to both host roots and performs ZERO network calls", async () => {
+    const result = await skillSaveHandler({ name: "my-notes", content: body("my-notes") });
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain("LOCALLY");
+    for (const root of [".agents", ".claude"]) {
+      expect(await readFile(join(FAKE_HOME, root, "skills", "my-notes", "SKILL.md"), "utf8")).toContain("my-notes");
+    }
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mocks.trigger).not.toHaveBeenCalled();
+  });
+
+  it("signed out + explicit user scope: refuses with guidance instead of silently downgrading", async () => {
+    const result = await skillSaveHandler({ name: "my-notes", content: body("my-notes"), scope: "user" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("signed-in");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("explicit local scope stays local even when signed in", async () => {
+    mocks.getSynaluxJwt.mockResolvedValue("jwt");
+    const result = await skillSaveHandler({ name: "my-notes", content: body("my-notes"), scope: "local" });
+    expect(result.content[0].text).toContain("LOCALLY");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("skill_save — signed in", () => {
+  beforeEach(() => {
+    mocks.getSynaluxJwt.mockResolvedValue("jwt-token");
+  });
+
+  it("defaults to USER scope, uploads, states the classification and how to share", async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ status: "ok", version: 1 }), { status: 200 }));
+    mocks.trigger.mockResolvedValue(syncResult({ installed: ["my-notes"] }));
+    const result = await skillSaveHandler({ name: "my-notes", content: body("my-notes") });
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain("YOUR account skill");
+    expect(result.content[0].text).toContain("team skill");   // the how-to-share hint
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toContain("/api/v1/prism/user-skills");
+    expect((init as RequestInit).headers).toMatchObject({ Authorization: "Bearer jwt-token" });
+    expect(JSON.parse(String((init as RequestInit).body))).toMatchObject({ scope: "user", name: "my-notes" });
+  });
+
+  it("team scope passes workspace and targeting through; server refusals are relayed verbatim", async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ status: "error", error: "Team skills require a workspace owner/admin role" }), { status: 403 }));
+    const result = await skillSaveHandler({ name: "team-ops", content: body("team-ops"), scope: "team", workspace_id: "ws-1", assign_to: ["u-2"] });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("owner/admin");
+    expect(JSON.parse(String((fetchSpy.mock.calls[0][1] as RequestInit).body))).toMatchObject({ scope: "team", workspace_id: "ws-1", assign_to: ["u-2"] });
+  });
+
+  it("JOIN-STALE GUARD: when the first sync predates the save, a second sync runs", async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ status: "ok", version: 2 }), { status: 200 }));
+    mocks.trigger
+      .mockResolvedValueOnce(syncResult({ installed: ["something-else"] }))   // joined pre-save run
+      .mockResolvedValueOnce(syncResult({ updated: ["my-notes"] }));
+    const result = await skillSaveHandler({ name: "my-notes", content: body("my-notes") });
+    expect(mocks.trigger).toHaveBeenCalledTimes(2);
+    expect(result.content[0].text).toContain("delivered to this machine now");
+  });
+
+  it("client-side validation refuses before any network: oversize, bad name, missing frontmatter", async () => {
+    expect((await skillSaveHandler({ name: "my-notes", content: body("my-notes") + "x".repeat(26_000) })).isError).toBe(true);
+    expect((await skillSaveHandler({ name: "Bad Name", content: body("Bad Name") })).isError).toBe(true);
+    expect((await skillSaveHandler({ name: "my-notes", content: "# no frontmatter" })).isError).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("skill_manage — recall paths", () => {
+  it("deletes a local skill only after archiving its final content", async () => {
+    await skillSaveHandler({ name: "doomed", content: body("doomed", "precious body\n") });
+    const result = await skillManageHandler({ action: "delete", name: "doomed", scope: "local" });
+    expect(result.content[0].text).toContain("archived");
+    const archive = join(FAKE_HOME, ".prism-mcp", "skill-archive");
+    const entries = await readdir(archive);
+    const match = entries.find(entry => entry.startsWith("doomed-"));
+    expect(match).toBeTruthy();
+    expect(await readFile(join(archive, match!), "utf8")).toContain("precious body");
+    await expect(stat(join(FAKE_HOME, ".agents", "skills", "doomed"))).rejects.toThrow();
+  });
+
+  it("deletes an account skill by archiving the server-returned final content, then prunes", async () => {
+    mocks.getSynaluxJwt.mockResolvedValue("jwt");
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ status: "ok", deleted: { name: "gone", content: body("gone", "server copy\n"), version: 4 } }), { status: 200 }));
+    const result = await skillManageHandler({ action: "delete", name: "gone", scope: "user" });
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain("archived");
+    expect(mocks.trigger).toHaveBeenCalled();               // prune pass
+    const archive = join(FAKE_HOME, ".prism-mcp", "skill-archive");
+    const match = (await readdir(archive)).find(entry => entry.startsWith("gone-"));
+    expect(await readFile(join(archive, match!), "utf8")).toContain("server copy");
+  });
+
+  it("release relays the floor guard verbatim and restore round-trips", async () => {
+    mocks.getSynaluxJwt.mockResolvedValue("jwt");
+    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({ status: "error", error: "This skill is part of the protected floor and cannot be released: deployed clients validate the floor fail-closed, so honoring this would stop your skill sync entirely, not slim it." }), { status: 400 }));
+    const refused = await skillManageHandler({ action: "release", name: "ask-first", scope: "user" });
+    expect(refused.isError).toBe(true);
+    expect(refused.content[0].text).toContain("protected floor");
+
+    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({ status: "ok", action: "release", name: "winui-app" }), { status: 200 }));
+    const released = await skillManageHandler({ action: "release", name: "winui-app", scope: "user" });
+    expect(released.content[0].text).toContain("reversible");
+    fetchSpy.mockResolvedValueOnce(new Response(JSON.stringify({ status: "ok", action: "restore", name: "winui-app" }), { status: 200 }));
+    const restored = await skillManageHandler({ action: "restore", name: "winui-app", scope: "user" });
+    expect(restored.content[0].text).toContain("returns");
+  });
+
+  it("signed out: release explains the constraint instead of failing opaquely", async () => {
+    const result = await skillManageHandler({ action: "release", name: "winui-app", scope: "user" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("signed-in");
+  });
+});


### PR DESCRIPTION
Two new MCP tools that pair with the platform's per-account/team skill delivery.

## `skill_save` — three scopes, explicit classification
| Scope | Meaning |
|---|---|
| `local` | plain file on this machine only — works signed out (local-first untouched: **zero network calls**, pinned by test) |
| `user` | the signed-in account — follows the user to every machine via managed sync |
| `team` | a workspace — admin-writable, members receive it, optional `assign_to` targeting |

Explicit scope wins; signed-in default is **user** (stated in the result, with the how-to-share hint); `team` is never a default; explicit user/team while signed out refuses with guidance instead of silently downgrading.

## `skill_manage` — recall paths
- `release` / `restore`: deactivate a platform skill you never use (per user, or per team by admins), freeing host catalog budget — lossless to restore
- `delete`: removes a scoped skill everywhere, **archiving the final content locally first** (`~/.prism-mcp/skill-archive/`) — the row IS the content
- `list`: account + team + released + local-only dirs

## Verified subtleties
- **Join-stale guard**: a sync already in flight when the save lands can't contain it; the handler verifies arrival and re-runs once if needed
- **COMPAT, proven against the real validator**: written as an every-tier proof, refuted twice — deployed clients require a paid `minimum_plan` on native skills and validate free manifests as *exactly* the startup package. The shipped contract (paid-tier-only, `minimum_plan: standard`) is what the failures dictated, and the free-tier rejection is pinned so the server side can't be re-loosened into bricking old free clients.

11 scope tests + compat proof · full suite 3835 · build clean.