### PR TITLE
fix(release): hold package-lock.json to the package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prism-mcp-server",
-  "version": "20.8.1",
+  "version": "20.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prism-mcp-server",
-      "version": "20.8.1",
+      "version": "20.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",

--- a/scripts/check-publish-clean.mjs
+++ b/scripts/check-publish-clean.mjs
@@ -42,6 +42,35 @@ const VERSIONED_MANIFESTS = [
   "plugins/prism/.claude-plugin/plugin.json",
 ];
 
+/**
+ * package-lock.json states the package version TWICE and neither field is
+ * updated by editing package.json. Found 2026-08-11 by an external review:
+ * the lockfile had said 20.8.1 across three shipped releases (20.8.2, 20.9.0,
+ * 20.9.1) because nothing checked it. Harmless to the published tarball —
+ * npm rewrites the version on pack — but it makes the lockfile lie to every
+ * contributor, to `npm ci` provenance, and to anyone diffing a release. Same
+ * failure the manifest guard above already exists for, one file wider.
+ */
+function checkLockfileVersion(repoRoot, expected) {
+  let raw;
+  try {
+    raw = readFileSync(join(repoRoot, "package-lock.json"), "utf8");
+  } catch (error) {
+    if (error && error.code === "ENOENT") return [];
+    throw error;
+  }
+  const lock = JSON.parse(raw);
+  const problems = [];
+  if (lock.version !== expected) {
+    problems.push(`package-lock.json version is ${lock.version}, expected ${expected}`);
+  }
+  const rootPackage = lock.packages?.[""];
+  if (rootPackage && rootPackage.version !== expected) {
+    problems.push(`package-lock.json packages[""].version is ${rootPackage.version}, expected ${expected}`);
+  }
+  return problems;
+}
+
 function checkVersionedManifests(repoRoot, expected) {
   const problems = [];
   for (const relative of VERSIONED_MANIFESTS) {
@@ -79,6 +108,7 @@ function checkManifestVersions(repoRoot) {
   return [
     ...serverManifestVersionMismatches(packageJson, serverJson),
     ...checkVersionedManifests(repoRoot, packageJson.version),
+    ...checkLockfileVersion(repoRoot, packageJson.version),
     ...serverDescriptionTooLong(serverJson),
   ];
 }


### PR DESCRIPTION
External review of the 20.9.1 artifact caught `package-lock.json` still saying **20.8.1** — in both the root `version` and `packages[""].version` — across **three shipped releases** (20.8.2, 20.9.0, 20.9.1). Editing `package.json` never touches those fields, and nothing checked them.

**Harmless to the published tarball** (npm rewrites the version on pack; `npm ci` succeeds either way). **Not harmless to the repo**, where the lockfile is the file people trust to say what a checkout is.

This is the same failure the versioned-manifest guard already exists for — `server.json` once sat ~19 majors behind, the Codex plugin manifest a full release — so the fix is **the guard**, not just the value. The publish gate now refuses to ship while either lockfile field disagrees with `package.json`.

**Mutation-verified**: reverting the lockfile to 20.8.1 makes the gate name that exact field (`package-lock.json version is 20.8.1, expected 20.9.1`); restoring it passes.

`npm ci --dry-run` clean · full suite **3836 passed**.