### PR TITLE
fix(skills): the overflow manifest binds the agent, it does not inform it

### DIFF
--- a/src/utils/skillBudget.ts
+++ b/src/utils/skillBudget.ts
@@ -127,7 +127,13 @@ export function assembleSkillBlock(
         block +=
             `\n\n[📦 SKILLS NOT INLINED — max_tokens budget reached]\n` +
             `${overflow.join(", ")}\n` +
-            `To inline them, re-call session_load_context with a higher max_tokens.`;
+            `These are RULES YOU ARE BOUND BY, not optional reading — only their text ` +
+            `was withheld for budget. Before acting on work a listed skill governs ` +
+            `(e.g. verified-shipping before any completion claim, push, or PR), load ` +
+            `its body first: invoke it via the host's Skill tool, read it from the ` +
+            `skills directory, or re-call session_load_context with a higher ` +
+            `max_tokens. Claiming done without consulting the governing skill is the ` +
+            `exact failure this list exists to prevent.`;
     }
 
     return { block, inlined, overflow };

--- a/tests/skill-budget.test.ts
+++ b/tests/skill-budget.test.ts
@@ -62,6 +62,14 @@ describe('assembleSkillBlock', () => {
       entry({ name: 'skipped-two', content: K(1000) }),
     ], 200);
     expect(r.block).toContain('SKILLS NOT INLINED');
+    // The overflow manifest is an INSTRUCTION, not metadata. The 2026-08-11
+    // incident: verified-shipping sat name-only in this list while an agent
+    // claimed UI fixes it never rendered — the passive wording invited
+    // skipping. The message must bind the agent to consult the governing
+    // skill before completion claims, and must name the mechanism.
+    expect(r.block).toContain('RULES YOU ARE BOUND BY');
+    expect(r.block).toContain('before any completion claim');
+    expect(r.block).toContain('Skill tool');
     expect(r.block).toContain('skipped-one, skipped-two');
     expect(r.block).toContain('re-call session_load_context with a higher max_tokens');
   });


### PR DESCRIPTION
Companion to the synalux routing fix for the 2026-08-11 incident: an agent claimed three UI fixes it never rendered while `verified-shipping` — the skill defining what evidence a completion claim requires — sat **name-only in the overflow list of its own session context**.

The passive wording ("To inline them, re-call with a higher max_tokens") framed withheld rules as optional extra reading. Under task pressure, optional reading loses.

The manifest now states what the list IS — **rules the agent is bound by** whose text was withheld for budget — with the consequence spelled out (load the governing skill before any completion claim, push, or PR) and every mechanism named: the host's Skill tool, the skills directory, or a higher-budget reload.

Routing inlines the DoD bodies for prompts it can recognize; this line is the backstop for prompts it can't.

Pinned by test (binding phrase + completion-claim consequence + Skill-tool mechanism). Full suite 3836 green.