### PR TITLE
fix(skills): the budget tranche is additive over the floor — as documented

### DIFF
--- a/src/utils/skillBudget.ts
+++ b/src/utils/skillBudget.ts
@@ -109,14 +109,30 @@ export function assembleSkillBlock(
     const unbudgeted = !Number.isFinite(budgetChars) || budgetChars <= 0;
 
     let block = "";
+    let unprotectedChars = 0;
     const inlined: string[] = [];
     const overflow: string[] = [];
 
     for (const e of ordered) {
         const piece = render(e);
-        // Protected always inline; others only while they fit.
-        if (unbudgeted || e.protected || block.length + piece.length <= budgetChars) {
+        // Protected always inline and NEVER debit the budget: the tranche is
+        // documented as ADDITIVE on top of the floor. The previous check
+        // compared block.length — which the floor had already filled — so with
+        // a ~46KB floor against 2-16KB tranches, NO unprotected skill ever
+        // inlined at any normal budget. Rank was irrelevant; the budget was
+        // pre-spent. Found 2026-08-11 tracing why a prompt-matched
+        // verified-shipping still sat in overflow while an agent shipped
+        // unverified UI claims; the 2026-08-03 note ("no unprotected universal
+        // was ever inlined") had recorded this symptom and it was treated by
+        // protecting one skill instead of fixing the accounting.
+        if (unbudgeted || e.protected) {
             block += piece;
+            inlined.push(e.name);
+            continue;
+        }
+        if (unprotectedChars + piece.length <= budgetChars) {
+            block += piece;
+            unprotectedChars += piece.length;
             inlined.push(e.name);
         } else {
             overflow.push(e.name);

--- a/tests/skill-budget.test.ts
+++ b/tests/skill-budget.test.ts
@@ -93,9 +93,31 @@ describe('assembleSkillBlock', () => {
     for (let i = 0; i < 19; i++) entries.push(entry({ name: `tail${i}`, priority: 100 + i, content: K(4000) }));
     const r = assembleSkillBlock(entries, 8400);
     expect(r.inlined.filter(n => n.startsWith('prot')).length).toBe(13); // floor holds over budget
-    expect(r.inlined.filter(n => n.startsWith('tail')).length).toBe(0);  // tail waits for budget
-    expect(r.overflow.length).toBe(19);                                  // flood prevented, all named
-    expect(r.block.length).toBeLessThan(44_000);                         // preserves >1k headroom
+    // The tranche is ADDITIVE on top of the floor. This assertion previously
+    // expected 0 — pinning the bug as intent: the floor debited the budget, so
+    // with floor > tranche NOTHING unprotected ever inlined, at any level,
+    // for anyone. 8,400 chars buys exactly two 4K tail skills.
+    expect(r.inlined.filter(n => n.startsWith('tail')).length).toBe(2);
+    expect(r.overflow.length).toBe(17);                                  // flood prevented, all named
+    expect(r.block.length).toBeLessThan(52_000);                         // floor + tranche + manifest
+  });
+
+  it('INCIDENT 2026-08-11: a prompt-matched skill inlines even when the floor alone exceeds the budget', () => {
+    // An agent shipped unverified UI claims while verified-shipping — prompt-
+    // matched for its task — sat name-only in overflow. Routing gave it rank;
+    // the accounting bug made rank irrelevant. This is the shape that must
+    // never regress: floor 39K, budget 8,400, one prompt-matched 4.6K skill.
+    const protSizes = [2513, 2173, 5000, 1619, 1462, 2092, 1896, 1683, 2186, 7066, 3913, 3354, 4035];
+    const entries: SkillEntryForBudget[] = protSizes.map((n, i) =>
+      entry({ name: `prot${i}`, protected: true, priority: i, content: K(n) }));
+    entries.push(entry({ name: 'verified-shipping', category: 'prompt', priority: 200, content: K(4600) }));
+    for (let i = 0; i < 19; i++) entries.push(entry({ name: `tail${i}`, priority: 100 + i, content: K(4000) }));
+    const r = assembleSkillBlock(entries, 8400);
+    expect(r.inlined).toContain('verified-shipping');       // the DoD checklist arrives
+    expect(r.block).toContain('[📜 SKILL: verified-shipping]');
+    expect(r.overflow).not.toContain('verified-shipping');
+    // Prompt category outranks tail: the matched skill spends first.
+    expect(r.inlined.filter(n => n.startsWith('tail')).length).toBeLessThanOrEqual(1);
   });
 });
 


### PR DESCRIPTION
The root layer of the 2026-08-11 unverified-UI-claims incident: assembleSkillBlock debited the protected floor (~39-46KB) against tranches of 2,000-16,000 chars, so **no unprotected skill has ever inlined at any normal budget**. Routing rank was irrelevant — the budget was pre-spent. One test pinned the bug as intent. Fix: unprotected content debits its own counter, matching the documented ADDITIVE contract. Incident-shaped regression added and mutation-verified (reverted accounting fails it). Full suite 3,837.