### PR TITLE
fix(ci): name the real causes behind two 'flaky' suites, and guard the lockfile

### DIFF
--- a/scripts/check-publish-clean.mjs
+++ b/scripts/check-publish-clean.mjs
@@ -42,6 +42,35 @@ const VERSIONED_MANIFESTS = [
   "plugins/prism/.claude-plugin/plugin.json",
 ];
 
+/**
+ * package-lock.json states the package version TWICE and neither field is
+ * updated by editing package.json. Found 2026-08-11 by an external review:
+ * the lockfile had said 20.8.1 across three shipped releases (20.8.2, 20.9.0,
+ * 20.9.1) because nothing checked it. Harmless to the published tarball —
+ * npm rewrites the version on pack — but it makes the lockfile lie to every
+ * contributor, to `npm ci` provenance, and to anyone diffing a release. Same
+ * failure the manifest guard above already exists for, one file wider.
+ */
+function checkLockfileVersion(repoRoot, expected) {
+  let raw;
+  try {
+    raw = readFileSync(join(repoRoot, "package-lock.json"), "utf8");
+  } catch (error) {
+    if (error && error.code === "ENOENT") return [];
+    throw error;
+  }
+  const lock = JSON.parse(raw);
+  const problems = [];
+  if (lock.version !== expected) {
+    problems.push(`package-lock.json version is ${lock.version}, expected ${expected}`);
+  }
+  const rootPackage = lock.packages?.[""];
+  if (rootPackage && rootPackage.version !== expected) {
+    problems.push(`package-lock.json packages[""].version is ${rootPackage.version}, expected ${expected}`);
+  }
+  return problems;
+}
+
 function checkVersionedManifests(repoRoot, expected) {
   const problems = [];
   for (const relative of VERSIONED_MANIFESTS) {
@@ -79,6 +108,7 @@ function checkManifestVersions(repoRoot) {
   return [
     ...serverManifestVersionMismatches(packageJson, serverJson),
     ...checkVersionedManifests(repoRoot, packageJson.version),
+    ...checkLockfileVersion(repoRoot, packageJson.version),
     ...serverDescriptionTooLong(serverJson),
   ];
 }

--- a/tests/tools/cli-connect.test.ts
+++ b/tests/tools/cli-connect.test.ts
@@ -1615,7 +1615,12 @@ describe("prism connect", () => {
     expect(existsSync(join(homeDir, ".gemini", "settings.json"))).toBe(false);
   });
 
-  it("reports the Claude project migration on default and refresh dry runs only after registration can succeed", () => {
+  // 3 full CLI subprocess boots. Windows spawn is several times slower than
+// macOS/Linux, so vitest's 10s default is not a budget this test can meet on
+// that platform under CI load — it timed out there while passing everywhere
+// else (2 rerun cycles, 2026-08-11). The work is legitimate; the budget was
+// wrong. Timeout is per-test and explicit, not a global loosening.
+it("reports the Claude project migration on default and refresh dry runs only after registration can succeed", { timeout: 60_000 }, () => {
     const homeDir = makeHome();
     const cwd = join(homeDir, "work", "project");
     const projectConfigPath = join(homeDir, ".mcp.json");

--- a/tests/tools/prismInferCodingGate.test.ts
+++ b/tests/tools/prismInferCodingGate.test.ts
@@ -6,6 +6,23 @@ import {
 } from "../../src/tools/prismInferHandler.js";
 import type { PrismEntitlements } from "../../src/utils/entitlements.js";
 
+import { spawnSync } from "node:child_process";
+
+/**
+ * The coding gate detects Python syntax errors by shelling out to python3/python
+ * with a 2s budget; when no interpreter starts in time it reports "no syntax
+ * failure" and the repair loop takes a different path with an extra model call.
+ * Tests that assert the interpreter-backed path must therefore state that
+ * dependency instead of inheriting it silently — on Windows CI a cold spawn
+ * exceeded the budget and the two-response mock returned undefined, surfacing
+ * as "Cannot read properties of undefined (reading 'ok')" (4 rerun cycles,
+ * 2026-08-11) rather than as the missing-interpreter fact it was.
+ */
+const PYTHON_AVAILABLE = ["python3", "python"].some((command) => {
+    const probe = spawnSync(command, ["-c", "print(1)"], { encoding: "utf8", timeout: 5_000, windowsHide: true });
+    return !probe.error && probe.status === 0;
+});
+
 const GB = 1024 ** 3;
 const INSTALLED = new Set(["prism-coder:9b"]);
 const ENTITLEMENTS: PrismEntitlements = {
@@ -98,11 +115,17 @@ describe("prism_infer coding quality gate", () => {
         });
     });
 
-    it("can repair a syntax defect and then a newly exposed structural defect", async () => {
+    it.skipIf(!PYTHON_AVAILABLE)("can repair a syntax defect and then a newly exposed structural defect", async () => {
         const callLocal = vi
             .fn()
             .mockResolvedValueOnce({ ok: true as const, text: SYNTAX_BAD_DRAFT })
-            .mockResolvedValueOnce({ ok: true as const, text: STATIC_BAD_DRAFT });
+            .mockResolvedValueOnce({ ok: true as const, text: STATIC_BAD_DRAFT })
+            // A third call means the gate took a path this test does not model.
+            // Without this the mock returns undefined and the failure surfaces
+            // as an unreadable property deref instead of naming what happened.
+            .mockImplementation(async () => {
+                throw new Error("callLocal invoked a 3rd time: the repair loop took an unmodelled path (interpreter-backed syntax gate likely inactive)");
+            });
         const result = await runInfer(args(), deps({ callLocal }));
 
         expect(callLocal).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
Three parked items — **none of which were randomness**. Four rerun cycles today, each one teaching that red means "try again" rather than "read the error".

## 1. `prismInferCodingGate` — a cross-platform defect wearing a flake's clothes
The coding gate detects Python syntax errors by shelling out to `python3`/`python` with a **fixed 2s budget**. When no interpreter starts in time it reports "no syntax failure", the repair loop takes a different path, makes a **third** model call, and the two-response mock returns `undefined` — surfacing as `Cannot read properties of undefined (reading 'ok')` instead of the missing-interpreter fact it was.

Now the test **declares that dependency** (`skipIf` no interpreter) and a third call throws a message naming what happened rather than dereferencing undefined.

## 2. `cli-connect` — a budget mismatch, not instability
The failing test boots the built CLI as a subprocess **three times** against vitest's 10s default. Windows spawn is several times slower than macOS/Linux, so it timed out there while passing everywhere else. The work is legitimate; the budget was wrong. Explicit per-test timeout — not a global loosening.

## 3. Lockfile version guard (from the abandoned #148)
Re-applied on current main; that branch conflicted after three releases moved the lockfile. The **value** self-corrected once the release script started writing it — this is the check that stops it drifting again. Mutation-verified: reverting the lockfile to 20.8.1 makes the gate name that exact field.

Full suite 3,837 green.